### PR TITLE
Added custom wait timeouts for UIItemContainer.Get() and Window.WaitTill().

### DIFF
--- a/src/TestStack.White/UIItems/UIItemContainer.cs
+++ b/src/TestStack.White/UIItems/UIItemContainer.cs
@@ -89,19 +89,29 @@ namespace White.Core.UIItems
         }
 
         /// <summary>
-        /// Finds UIItem which matches specified type and searchCriteria. Look at documentation of SearchCriteria for details on it.
+        /// Finds UIItem which matches specified type and searchCriteria using the default BusyTimeout. Look at documentation of SearchCriteria for details on it.
         /// </summary>
         /// <param name="searchCriteria">Criteria provided to search UIItem</param>
         /// <returns>First items matching the criteria</returns>
         public virtual IUIItem Get(SearchCriteria searchCriteria)
+        {
+            return Get(searchCriteria, CoreAppXmlConfiguration.Instance.BusyTimeout());
+        }
+
+        /// <summary>
+        /// Finds UIItem which matches specified type and searchCriteria. Look at documentation of SearchCriteria for details on it.
+        /// </summary>
+        /// <param name="searchCriteria">Criteria provided to search UIItem</param>
+        /// <param name="timeout">Time to wait for item to come on-screen before returning off-screen element, if found.</param>
+        /// <returns>First items matching the criteria</returns>
+        public virtual IUIItem Get(SearchCriteria searchCriteria, TimeSpan timeout)
         {
             try
             {
                 var uiItem = Retry.For(() =>
                     CurrentContainerItemFactory.Find(searchCriteria, WindowSession),
                     b =>(bool)b.AutomationElement.GetCurrentPropertyValue(AutomationElement.IsOffscreenProperty, false),
-                    // Wait until control is onscreen
-                    CoreAppXmlConfiguration.Instance.BusyTimeout());
+                    timeout);
 
                 if (uiItem == null)
                 {

--- a/src/TestStack.White/UIItems/WindowItems/Window.cs
+++ b/src/TestStack.White/UIItems/WindowItems/Window.cs
@@ -251,7 +251,12 @@ UI actions on window needing mouse would not work in area not falling under the 
 
         public virtual void WaitTill(WaitTillDelegate waitTillDelegate)
         {
-            if (!Retry.For(()=>waitTillDelegate(), CoreAppXmlConfiguration.Instance.BusyTimeout()))
+            WaitTill(waitTillDelegate, CoreAppXmlConfiguration.Instance.BusyTimeout());
+        }
+
+        public virtual void WaitTill(WaitTillDelegate waitTillDelegate, TimeSpan timeout)
+        {
+            if (!Retry.For(() => waitTillDelegate(), timeout, new TimeSpan?()))
                 throw new UIActionException("Time out happened" + Constants.BusyMessage);
         }
 


### PR DESCRIPTION
While automating a project we found that we wanted to find certain UI
elements that were off-screen or hidden. Because of how Get() works we have
to wait until the BusyTimeout had passed before it would return. We also
found that sometimes there were special actions that we knew would take
significantly longer than other actions, but WaitTill() would timeout
before those actions were completed unless we increased the BusyTimeout.

These two scenarios worked against each other, increasing the BusyTimeout
would make one take much longer, and is only needed for a few special cases
while making it shorter would cause some tests to fail. I added another
overload to each of those methods where you can give a custom TimeSpan to
fix this problem.
