### PR TITLE
Fix for issue #31: Makes it possible to enter keyboard values that requires Ctrl or Alt key

### DIFF
--- a/src/TestStack.White.UITests/InputDevices/KeyboardTest.cs
+++ b/src/TestStack.White.UITests/InputDevices/KeyboardTest.cs
@@ -23,7 +23,7 @@ namespace White.Core.UITests.InputDevices
             keyboard.LeaveAllKeys();
         }
 
-        [Test, Ignore]
+        [Test]
         public void EnterAccentedChars()
         {
             textBox.BulkText = "דאגהבדאגהבדאגהבדאגהבדאגהבדאגהבדאגהבדאגהב";

--- a/src/TestStack.White/InputDevices/Keyboard.cs
+++ b/src/TestStack.White/InputDevices/Keyboard.cs
@@ -73,8 +73,12 @@ namespace White.Core.InputDevices
                 if (c.Equals('\r')) continue;
 
                 if (ShiftKeyIsNeeded(key)) SendKeyDown((short) KeyboardInput.SpecialKeys.SHIFT, false);
+                if (CtrlKeyIsNeeded(key)) SendKeyDown((short) KeyboardInput.SpecialKeys.CONTROL, false);
+                if (AltKeyIsNeeded(key)) SendKeyDown((short) KeyboardInput.SpecialKeys.ALT, false);
                 Press(key, false);
                 if (ShiftKeyIsNeeded(key)) SendKeyUp((short) KeyboardInput.SpecialKeys.SHIFT, false);
+                if (CtrlKeyIsNeeded(key)) SendKeyUp((short) KeyboardInput.SpecialKeys.CONTROL, false);
+                if (AltKeyIsNeeded(key)) SendKeyUp((short) KeyboardInput.SpecialKeys.ALT, false);
             }
 
             actionListener.ActionPerformed(Action.WindowMessage);
@@ -129,6 +133,16 @@ namespace White.Core.InputDevices
         private static bool ShiftKeyIsNeeded(short key)
         {
             return ((key >> 8) & 1) == 1;
+        }
+
+        private static bool CtrlKeyIsNeeded(short key)
+        {
+            return ((key >> 8) & 2) == 2;
+        }
+
+        private static bool AltKeyIsNeeded(short key)
+        {
+            return ((key >> 8) & 4) == 4;
         }
 
         private void SendKeyUp(short b, bool specialKey)


### PR DESCRIPTION
This fix makes the test KeyboardTest.ShouldSetTheValueOfATextBox pass on
non-US keyboards that requires the use of Ctrl or Alt.

Furthermore, it makes Keyboard work for characters that requires Alt or Ctrl to be pressed to enter the character. And it enabled the KeyboardTests.EnterAccentedChars tests.
