### PR TITLE
Grid Cell getting fixes and tests.

### DIFF
--- a/src/TestApplications/WindowsFormsTestApplication/Form1.Designer.cs
+++ b/src/TestApplications/WindowsFormsTestApplication/Form1.Designer.cs
@@ -32,8 +32,12 @@
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.listControls1 = new WindowsFormsTestApplication.ListControls();
             this.inputControls1 = new WindowsFormsTestApplication.InputControls();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.DataGridControl = new System.Windows.Forms.DataGridView();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
+            this.groupBox3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.DataGridControl)).BeginInit();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -46,6 +50,13 @@
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "List Controls";
             // 
+            // listControls1
+            // 
+            this.listControls1.Location = new System.Drawing.Point(6, 19);
+            this.listControls1.Name = "listControls1";
+            this.listControls1.Size = new System.Drawing.Size(260, 204);
+            this.listControls1.TabIndex = 0;
+            // 
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.inputControls1);
@@ -56,13 +67,6 @@
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Input Controls";
             // 
-            // listControls1
-            // 
-            this.listControls1.Location = new System.Drawing.Point(6, 19);
-            this.listControls1.Name = "listControls1";
-            this.listControls1.Size = new System.Drawing.Size(260, 204);
-            this.listControls1.TabIndex = 0;
-            // 
             // inputControls1
             // 
             this.inputControls1.Location = new System.Drawing.Point(7, 19);
@@ -70,11 +74,30 @@
             this.inputControls1.Size = new System.Drawing.Size(217, 181);
             this.inputControls1.TabIndex = 0;
             // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.DataGridControl);
+            this.groupBox3.Location = new System.Drawing.Point(532, 12);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(200, 276);
+            this.groupBox3.TabIndex = 5;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Grid View";
+            // 
+            // DataGridControl
+            // 
+            this.DataGridControl.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DataGridControl.Location = new System.Drawing.Point(7, 20);
+            this.DataGridControl.Name = "DataGridControl";
+            this.DataGridControl.Size = new System.Drawing.Size(187, 250);
+            this.DataGridControl.TabIndex = 0;
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(751, 405);
+            this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Name = "Form1";
@@ -82,6 +105,8 @@
             this.Text = "Form1";
             this.groupBox1.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
+            this.groupBox3.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.DataGridControl)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -92,6 +117,8 @@
         private ListControls listControls1;
         private System.Windows.Forms.GroupBox groupBox2;
         private InputControls inputControls1;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.DataGridView DataGridControl;
     }
 }
 

--- a/src/TestApplications/WindowsFormsTestApplication/Form1.cs
+++ b/src/TestApplications/WindowsFormsTestApplication/Form1.cs
@@ -7,6 +7,19 @@ namespace WindowsFormsTestApplication
         public Form1()
         {
             InitializeComponent();
+            DataGridControl.DataSource = TestItems;
+        }
+
+        public TestItem[] TestItems
+        {
+            get
+            {
+                return new[]{
+                               new TestItem {Id = 1, Contents = "Item1", Description = "Simple item 1"}, 
+                               new TestItem {Id = 2, Contents = "Item2", Description = ""},
+                               new TestItem {Id = 3, Contents = "Item3"}
+                           };
+            }
         }
     }
 }

--- a/src/TestApplications/WindowsFormsTestApplication/Program.cs
+++ b/src/TestApplications/WindowsFormsTestApplication/Program.cs
@@ -18,4 +18,11 @@ namespace WindowsFormsTestApplication
             Application.Run(new Form1());
         }
     }
+
+    public class TestItem
+    {
+        public int Id { get; set; }
+        public string Contents { get; set; }
+        public string Description { get; set; }
+    }
 }

--- a/src/TestApplications/WpfTestApplication/HelpClasses.cs
+++ b/src/TestApplications/WpfTestApplication/HelpClasses.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WpfTestApplication
+{
+    public class TestItem
+    {
+        public int Id { get; set; }
+        public string Contents { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/src/TestApplications/WpfTestApplication/MainWindow.xaml
+++ b/src/TestApplications/WpfTestApplication/MainWindow.xaml
@@ -9,6 +9,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <GroupBox Header="List Controls" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Name="AGroupBox">
             <wpfTestApplication:ListControls />
@@ -21,6 +22,9 @@
                 <Button Content="Launch Horizontal GridSplitter Window" Click="LaunchHorizontalGridSplitter" AutomationProperties.AutomationId ="OpenHorizontalSplitterButton" />
                 <Button Content="Launch Vertical GridSplitter Window" Click="LaunchVerticalGridSplitter" AutomationProperties.AutomationId ="OpenVerticalSplitterButton"/>
             </StackPanel>
+        </GroupBox>
+        <GroupBox Header="Data grid" Grid.Column="3">
+            <DataGrid x:Name="DataGridControl" AutoGenerateColumns="True" ItemsSource="{Binding Path = TestItems}"/>
         </GroupBox>
     </Grid>
 </Window>

--- a/src/TestApplications/WpfTestApplication/MainWindow.xaml.cs
+++ b/src/TestApplications/WpfTestApplication/MainWindow.xaml.cs
@@ -35,5 +35,17 @@ namespace WpfTestApplication
         {
             new VerticalGridSplitter().Show();
         }
+
+        public TestItem[] TestItems        
+        {
+            get            
+            {
+                return new[]{
+                               new TestItem {Id = 1, Contents = "Item1", Description = "Simple item 1"}, 
+                               new TestItem {Id = 2, Contents = "Item2", Description = ""},
+                               new TestItem {Id = 3, Contents = "Item3"}
+                           };
+            }
+        }
     }
 }

--- a/src/TestApplications/WpfTestApplication/WpfTestApplication.csproj
+++ b/src/TestApplications/WpfTestApplication/WpfTestApplication.csproj
@@ -77,6 +77,7 @@
     <Compile Include="HorizontalGridSplitter.xaml.cs">
       <DependentUpon>HorizontalGridSplitter.xaml</DependentUpon>
     </Compile>
+    <Compile Include="HelpClasses.cs" />
     <Compile Include="ListControls.xaml.cs">
       <DependentUpon>ListControls.xaml</DependentUpon>
     </Compile>

--- a/src/TestStack.White.UITests.Old/MessageBoxTest.cs
+++ b/src/TestStack.White.UITests.Old/MessageBoxTest.cs
@@ -24,7 +24,9 @@ namespace White.Core.UITests
         {
             Window.Get<Button>("buttonLaunchesMessageBox").Click();
             Window messageBox = Window.MessageBox("Close Me");
-            messageBox.Get<Button>(SearchCriteria.ByText("OK")).Click();
+            // the same problem with default text localization, so in regular message box
+            // we have Close (x) button with "Close" id and OK button with "2" id
+            messageBox.Get<Button>(SearchCriteria.ByAutomationId("2")).Click();
         }
     }
 }

--- a/src/TestStack.White.UITests/ControlTests/DataGridTests.cs
+++ b/src/TestStack.White.UITests/ControlTests/DataGridTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using TestStack.White.UITests.Infrastructure;
+using White.Core.UIItems;
+using White.Core.UIItems.Finders;
+using White.Core.UIItems.TableItems;
+
+namespace TestStack.White.UITests.ControlTests
+{
+    public class DataGridTests : WhiteTestBase
+    {
+        protected ListView DataGridWpfUnderTest { get; set; }
+        protected Table DataGridWinFormsUnderTest { get; set; }
+
+        protected override void RunTest(WindowsFramework framework)
+        {
+            if (framework == WindowsFramework.Wpf)
+            {
+                DataGridWpfUnderTest = MainWindow.Get<ListView>(SearchCriteria.ByAutomationId("DataGridControl"));
+                RunTest(CanGetAllItemsWpf);
+                RunTest(CanGetCellWpf);
+            }
+            else if (framework == WindowsFramework.WinForms)
+            {
+                DataGridWinFormsUnderTest = MainWindow.Get<Table>(SearchCriteria.ByAutomationId("DataGridControl"));
+                RunTest(CanGetAllItemsWinforms);
+            }
+        }
+
+        void CanGetAllItemsWpf()
+        {
+            var rows = DataGridWpfUnderTest.Rows;
+            Assert.AreEqual(3, rows.Count);
+            var row1 = rows.Get(0);
+            Assert.AreEqual(3, row1.Cells.Count);
+            Assert.AreEqual("1", row1.Cells[0].Text);
+            Assert.AreEqual("Item1", row1.Cells[1].Text);
+            StringAssert.Contains("Simple", row1.Cells[2].Text);
+        }
+
+        void CanGetCellWpf()
+        {
+            Assert.AreEqual("Item1", DataGridWpfUnderTest.Cell("Contents", 0).Text);
+            Assert.AreEqual("Item2", DataGridWpfUnderTest.Cell("Contents", 1).Text);
+            Assert.AreEqual("Item3", DataGridWpfUnderTest.Cell("Contents", 2).Text);
+        }
+
+        void CanGetAllItemsWinforms()
+        {
+            var rows = DataGridWinFormsUnderTest.Rows;
+            Assert.AreEqual(3, rows.Count);
+            var row1 = rows[0];
+            Assert.AreEqual(3, row1.Cells.Count);
+            Assert.AreEqual("1", row1.Cells[0].Value);
+            Assert.AreEqual("Item1", row1.Cells[1].Value);
+            StringAssert.Contains("Simple", (string)row1.Cells[2].Value);
+        }
+
+        protected override IEnumerable<WindowsFramework> SupportedFrameworks()
+        {
+            yield return WindowsFramework.WinForms;
+            yield return WindowsFramework.Wpf;
+        }
+    }
+}

--- a/src/TestStack.White.UITests/ControlTests/WPF/DataGridTests.cs
+++ b/src/TestStack.White.UITests/ControlTests/WPF/DataGridTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using TestStack.White.UITests.Infrastructure;
+using White.Core.UIItems;
+using White.Core.UIItems.Finders;
+using White.Core.UIItems.WPFUIItems;
+
+namespace TestStack.White.UITests.ControlTests.WPF
+{
+    public class DataGridTests : WhiteTestBase
+    {
+        protected ListView DataGridUnderTest { get; set; }
+        protected ListView DataGridFromCustomControlUnderTest { get; set; }
+
+        protected override void RunTest(WindowsFramework framework)
+        {
+            DataGridUnderTest = MainWindow.Get<ListView>(SearchCriteria.ByAutomationId("DataGridControl"));
+            var customControl = MainWindow.Get(SearchCriteria.ByAutomationId("CustomDataGridControl")) as UIItem;
+            DataGridFromCustomControlUnderTest = customControl.Get<ListView>(SearchCriteria.ByAutomationId("DataGridControl"));
+
+            RunTest(() => CanGetAllItems(DataGridUnderTest));
+            RunTest(() => CanGetAllItems(DataGridFromCustomControlUnderTest));
+            RunTest(() => CanGetCell(DataGridUnderTest));
+            RunTest(() => CanGetCell(DataGridFromCustomControlUnderTest));
+        }
+
+        void CanGetAllItems(ListView dataGridUnderTest)
+        {
+            var rows = dataGridUnderTest.Rows;
+            Assert.AreEqual(3, rows.Count);
+            var row1 = rows.Get(0);
+            Assert.AreEqual(3, row1.Cells.Count);
+            Assert.AreEqual("1", row1.Cells[0].Text);
+            Assert.AreEqual("Item1", row1.Cells[1].Text);
+            StringAssert.Contains("Simple", row1.Cells[2].Text);
+        }
+
+        void CanGetCell(ListView dataGridUnderTest)
+        {
+            var cell = dataGridUnderTest.Cell("Contents", 0);
+            Assert.AreEqual("Item1", cell.Text);
+            Assert.AreEqual("Item2", dataGridUnderTest.Cell("Contents", 1).Text);
+            Assert.AreEqual("Item3", dataGridUnderTest.Cell("Contents", 2).Text);
+        }
+
+        protected override IEnumerable<WindowsFramework> SupportedFrameworks()
+        {
+            yield return WindowsFramework.Wpf;
+        }
+    }
+}

--- a/src/TestStack.White.UITests/TestStack.White.UITests.csproj
+++ b/src/TestStack.White.UITests/TestStack.White.UITests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ControlTests\UIItemTests.cs" />
     <Compile Include="ControlTests\ComboBoxTests.cs" />
     <Compile Include="ControlTests\DataBoundComboBoxTests.cs" />
+    <Compile Include="ControlTests\DataGridTests.cs" />
     <Compile Include="ControlTests\EditableComboBoxTests.cs" />
     <Compile Include="ControlTests\InputControls\DatePickerTests.cs" />
     <Compile Include="ControlTests\Splitters\DelegateDisposable.cs" />

--- a/src/TestStack.White/Factory/TableCellFactory.cs
+++ b/src/TestStack.White/Factory/TableCellFactory.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Automation;
 using White.Core.AutomationElementSearch;
-using White.Core.Configuration;
 using White.Core.UIItems.Actions;
 using White.Core.UIItems.TableItems;
 
@@ -25,12 +23,11 @@ namespace White.Core.Factory
         {
             if (customControlTypes == null)
                 customControlTypes = new AutomationElementFinder(tableElement).Descendants(AutomationSearchCondition.ByControlType(ControlType.Custom));
-            int zeroBasedRowNumber = int.Parse(rowElement.Current.Name.Split(' ').Last());
+            string rowNameSuffix = " " + rowElement.Current.Name;
             Predicate<AutomationElement> cellPredicate = element =>
             {
                 string name = element.Current.Name;
-                return name.Contains(UIItemIdAppXmlConfiguration.Instance.TableCellPrefix) &&
-                       zeroBasedRowNumber == int.Parse(name.Split(' ').Last());
+                return name.EndsWith(rowNameSuffix);
             };
             List<AutomationElement> tableCellElements = customControlTypes.FindAll(cellPredicate);
             return new TableCells(tableCellElements, tableHeader, actionListener);

--- a/src/TestStack.White/Factory/TableRowFactory.cs
+++ b/src/TestStack.White/Factory/TableRowFactory.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Windows.Automation;
 using White.Core.AutomationElementSearch;
-using White.Core.Configuration;
 using White.Core.UIItems.Actions;
 using White.Core.UIItems.TableItems;
 
@@ -12,13 +11,16 @@ namespace White.Core.Factory
     {
         private readonly AutomationElementFinder automationElementFinder;
         private static readonly Predicate<AutomationElement> RowPredicate;
+        private static int result;
 
         static TableRowFactory()
         {
             RowPredicate =
                 element =>
-                element.Current.Name.StartsWith(UIItemIdAppXmlConfiguration.Instance.TableColumn) &&
-                element.Current.Name.Split(' ').Length == 2;
+                element.Current.Name.Split(' ').Length == 2 &&
+                // row header containes no Numbers
+                (int.TryParse(element.Current.Name.Split(' ')[0], out result) ||
+                int.TryParse(element.Current.Name.Split(' ')[1], out result));
         }
 
         public TableRowFactory(AutomationElementFinder automationElementFinder)
@@ -34,9 +36,10 @@ namespace White.Core.Factory
 
         private List<AutomationElement> GetRowElements()
         {
-            List<AutomationElement> descendants = automationElementFinder.Descendants(AutomationSearchCondition.ByControlType(ControlType.Custom));
-            var automationElements = new List<AutomationElement>(descendants);
-            return automationElements.FindAll(RowPredicate);
+            // this will find only first level children of out element - rows
+            List<AutomationElement> descendants = automationElementFinder.Children(AutomationSearchCondition.ByControlType(ControlType.Custom));
+            var automationElements = new List<AutomationElement>(descendants.FindAll(RowPredicate));
+            return automationElements;
         }
 
         public virtual int NumberOfRows

--- a/src/TestStack.White/UIItems/IUIItemContainer.cs
+++ b/src/TestStack.White/UIItems/IUIItemContainer.cs
@@ -7,5 +7,6 @@ namespace White.Core.UIItems
         T Get<T>() where T : UIItem;
         T Get<T>(string primaryIdentification) where T : UIItem;
         T Get<T>(SearchCriteria searchCriteria) where T : UIItem;
+        IUIItem Get(SearchCriteria searchCriteria);
     }
 }

--- a/src/TestStack.White/UIItems/ListViewRow.cs
+++ b/src/TestStack.White/UIItems/ListViewRow.cs
@@ -39,7 +39,7 @@ namespace White.Core.UIItems
             get
             {
                 actionListener.ActionPerforming(this);
-                List<AutomationElement> collection = finder.Children(AutomationSearchCondition.ByControlType(ControlType.Text));
+                var collection = finder.Descendants(AutomationSearchCondition.ByControlType(ControlType.Text));
                 return new ListViewCells(collection, actionListener, header);
             }
         }


### PR DESCRIPTION
Fix: searching Rows and Cells in Table (Winforms.DataGridView) for localized versions of Windows and VS (the Name property can be in different language rather than English).
Add: controls added to corresponding versions of TestApplications. Tests for these controls added to TestStack.White.UITests project.
Fix: Old test for message box fixed for running in localized versions of Windows and VS (the button's Name property is in current locale language).
