### PR TITLE
Introducing Maximum & Minimum properties to Slider control

### DIFF
--- a/src/TestStack.White/UIItems/Slider.cs
+++ b/src/TestStack.White/UIItems/Slider.cs
@@ -23,6 +23,16 @@ namespace White.Core.UIItems
             set { RangePattern().SetValue(value); }
         }
 
+        public virtual double Maximum
+        {
+            get { return RangePattern().Current.Maximum; }
+        }
+
+        public virtual double Minimum
+        {
+            get { return RangePattern().Current.Minimum; }
+        }
+
         private RangeValuePattern RangePattern()
         {
             return ((RangeValuePattern)Pattern(RangeValuePattern.Pattern));


### PR DESCRIPTION
This commit introduces `Maximum` & `Minimum` properties to the `Slider` control. 

Before this commit, there was no way to get the maximum value for a Slider control. Because of this, it is not easy to slide to the end from a test because we don't know when to stop calling `LargeIncrementButton.Click()`.

With this in place, we can write the following from a test to slide to the end

``` csharp
var t = window.Get<Slider>(SearchCriteria.ByAutomationId("slider1"));
while (t.Value < t.Maximum)
{
      t.LargeIncrementButton.Click(); 
}
```
