### PR TITLE
Better DoExpand and DoCollapse for Win32TreeView

### DIFF
--- a/src/TestStack.White/UIItems/TreeItems/Win32TreeNode.cs
+++ b/src/TestStack.White/UIItems/TreeItems/Win32TreeNode.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Automation;
 using White.Core.UIA;
 using White.Core.UIItems.Actions;
+using White.Core.WindowsAPI;
 
 namespace White.Core.UIItems.TreeItems
 {
@@ -15,14 +16,16 @@ namespace White.Core.UIItems.TreeItems
         // would not work when there is an icon to left of the node.
         protected override void DoExpand()
         {
-            DoubleClick();
+            Click();
+            KeyIn(KeyboardInput.SpecialKeys.RIGHT);
             if (Nodes.Count == 0)
                 throw new AutomationException(string.Format("Cannot expand TreeNode {0}, expand button not visible", this), Debug.Details(AutomationElement));
         }
 
         protected override void DoCollapse()
         {
-            DoubleClick();
+            Click();
+            KeyIn(KeyboardInput.SpecialKeys.LEFT);
         }
 
         protected override Point SelectPoint


### PR DESCRIPTION
The original implementation was performing a DoubleClick on the item,
which often triggers some application-specific event.
Pressing the RIGHT and LEFT keys to expand-collapse trees is
a widely used idiom in applications and less likely to be
used for something else.

The exception message upon unsuccessful expanding hints that the
desired implementation would be to click on the expand button of
the tree item, yet I don't currently see a way to do that.
If it's not possible to do so, the error message should be
changed accordingly.
