### PR TITLE
Adds a UI test for title bar button clicks

### DIFF
--- a/src/TestStack.White.UITests/ControlTests/ToolbarCloseTest.cs
+++ b/src/TestStack.White.UITests/ControlTests/ToolbarCloseTest.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using White.Core.UIItems;
+
+namespace TestStack.White.UITests.ControlTests
+{
+    public class ToolbarCloseTest : WhiteTestBase
+    {
+        protected override void RunTest(WindowsFramework framework)
+        {
+            RunTest(ClickTitleBarClose);
+        }
+
+        private void ClickTitleBarClose()
+        {
+            MainWindow.TitleBar.CloseButton.Click();
+            Assert.True(Application.HasExited);
+        }
+
+        protected override IEnumerable<WindowsFramework> SupportedFrameworks()
+        {
+            yield return WindowsFramework.WinForms;
+        }
+    }
+}

--- a/src/TestStack.White.UITests/IMainWindow.cs
+++ b/src/TestStack.White.UITests/IMainWindow.cs
@@ -7,5 +7,6 @@ namespace TestStack.White.UITests
     {
         void Close();
         Window ModalWindow(string title);
+        TitleBar TitleBar { get; }
     }
 }

--- a/src/TestStack.White.UITests/TestStack.White.UITests.csproj
+++ b/src/TestStack.White.UITests/TestStack.White.UITests.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="ControlTests\CheckboxTest.cs" />
     <Compile Include="ControlTests\CheckedListBoxTest.cs" />
+    <Compile Include="ControlTests\ToolbarCloseTest.cs" />
     <Compile Include="ControlTests\TooltipTests.cs" />
     <Compile Include="ControlTests\UIItemTests.cs" />
     <Compile Include="ControlTests\ComboBoxTests.cs" />


### PR DESCRIPTION
The following procedure fails transiently on Winforms:

```
var win = [some window];
win.TitleBar.CloseButton.Click();
```

It is more likely to fail the simpler the form is. An empty form fails constantly while the current Winforms test application, with the test in this pull request, fails once every few test runs. It would seem like some kind of wait is missing, if it is at all possible to wait for the moment when the window is fully responsible.
