### PR TITLE
Added untyped native search criteria (e.g. for searching by RuntimeId property value)

### DIFF
--- a/src/TestStack.White/UIItems/Finders/SearchConditionFactory.cs
+++ b/src/TestStack.White/UIItems/Finders/SearchConditionFactory.cs
@@ -63,5 +63,11 @@ namespace TestStack.White.UIItems.Finders
             var automationElementProperty = new AutomationElementProperty(value, automationProperty.ProgrammaticName, automationProperty);
             return new SimpleSearchCondition(automationElement => automationElement.GetCurrentPropertyValue(automationProperty), automationElementProperty);
         }
+
+        public static SearchCondition CreateForNativeProperty(AutomationProperty automationProperty, object value)
+        {
+            var automationElementProperty = new AutomationElementProperty(value, automationProperty.ProgrammaticName, automationProperty);
+            return new SimpleSearchCondition(automationElement => automationElement.GetCurrentPropertyValue(automationProperty), automationElementProperty);
+        }
     }
 }

--- a/src/TestStack.White/UIItems/Finders/SearchCriteria.cs
+++ b/src/TestStack.White/UIItems/Finders/SearchCriteria.cs
@@ -92,6 +92,11 @@ namespace TestStack.White.UIItems.Finders
             return new SearchCriteria(SearchConditionFactory.CreateForNativeProperty(automationProperty, value));
         }
 
+        public static SearchCriteria ByNativeProperty(AutomationProperty automationProperty, object value)
+        {
+            return new SearchCriteria(SearchConditionFactory.CreateForNativeProperty(automationProperty, value));
+        }
+
         public static SearchCriteria ByControlType(Type testControlType, WindowsFramework framework)
         {
             var searchCriteria = new SearchCriteria(SearchConditionFactory.CreateForControlType(testControlType, framework));
@@ -196,6 +201,12 @@ namespace TestStack.White.UIItems.Finders
         }
 
         public virtual SearchCriteria AndNativeProperty(AutomationProperty automationProperty, bool value)
+        {
+            conditions.Insert(0, SearchConditionFactory.CreateForNativeProperty(automationProperty, value));
+            return this;
+        }
+
+        public virtual SearchCriteria AndNativeProperty(AutomationProperty automationProperty, object value)
         {
             conditions.Insert(0, SearchConditionFactory.CreateForNativeProperty(automationProperty, value));
             return this;


### PR DESCRIPTION
I wonder overall why to make all SearchCriteria ctors private? Is there specific reason to do this?
