### PR TITLE
Added Application main window activation after process startup.

### DIFF
--- a/src/TestStack.White/Application.cs
+++ b/src/TestStack.White/Application.cs
@@ -10,6 +10,7 @@ using TestStack.White.Factory;
 using TestStack.White.Sessions;
 using TestStack.White.UIItems.Finders;
 using TestStack.White.UIItems.WindowItems;
+using TestStack.White.WindowsAPI;
 
 namespace TestStack.White
 {
@@ -78,6 +79,8 @@ namespace TestStack.White
                 Logger.Error(error, ex);
                 throw;
             }
+            process.WaitForInputIdle(CoreAppXmlConfiguration.Instance.BusyTimeout);
+            NativeWindow.SetForegroundWindow(process.MainWindowHandle);
             //TODO Expose this, and make it capture output properly
             if (ConfigurationManager.AppSettings["CaptureAUTOutput"] != null)
             {

--- a/src/TestStack.White/WindowsAPI/NativeWindow.cs
+++ b/src/TestStack.White/WindowsAPI/NativeWindow.cs
@@ -20,6 +20,9 @@ namespace TestStack.White.WindowsAPI
         [DllImport("gdi32.dll")]
         private static extern COLORREF GetTextColor(IntPtr hdc);
 
+        [DllImport("user32.dll")]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+
         public NativeWindow(Point point)
         {
             handle = WindowFromPoint(new POINT((int) point.X, (int) point.Y));


### PR DESCRIPTION
Sometimes, especially when White-driven UI test started from console shell or another programmatic way, OS launches application under test in the background and test fails because of this. This commit fixes the problem.
