### PR TITLE
Added checkbox as possible control in a data grid cell

### DIFF
--- a/src/TestStack.White/UIItems/ListViewRow.cs
+++ b/src/TestStack.White/UIItems/ListViewRow.cs
@@ -39,7 +39,11 @@ namespace TestStack.White.UIItems
             get
             {
                 actionListener.ActionPerforming(this);
-                var collection = finder.Descendants(AutomationSearchCondition.ByControlType(ControlType.Text));
+                var collection = finder.Descendants(
+                        new AutomationSearchCondition(
+                            new OrCondition(
+                                AutomationSearchCondition.ByControlType(ControlType.Text).Condition,
+                                AutomationSearchCondition.ByControlType(ControlType.CheckBox).Condition)));
                 return new ListViewCells(collection, actionListener, header);
             }
         }


### PR DESCRIPTION
Fix for issue #174

If a (WPF) data grid cell representing a boolean variable is represented by a checkbox only, this cell is not found by the "Cells" property of TestStack.White.UIItems.ListViewRow - the latter searches only for descendants of type "Text". The proposed fix adds an "Or" condition with "Text" and "CheckBox" in it.
