### PR TITLE
Fix: problem with cursors that are not the same on my OS as hardcoded in the MouseCursor class

### DIFF
--- a/src/TestStack.White/InputDevices/MouseCursor.cs
+++ b/src/TestStack.White/InputDevices/MouseCursor.cs
@@ -1,16 +1,39 @@
+using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace TestStack.White.InputDevices
 {
     public class MouseCursor
     {
-        public static MouseCursor IShapedCursor = new MouseCursor(65555);
-        public static MouseCursor Pointer = new MouseCursor(65553);
-        public static readonly MouseCursor DefaultAndWait = new MouseCursor(65575);
-        public static readonly MouseCursor Wait = new MouseCursor(65557);
-        public static readonly MouseCursor SilverlightWait = new MouseCursor(65543);
-        public static MouseCursor SilverlightPointer = new MouseCursor(65539);
+        [DllImport("user32.dll")]
+        static extern IntPtr LoadCursor(IntPtr hInstance, IDC_STANDARD_CURSORS lpCursorName);
+
+        enum IDC_STANDARD_CURSORS
+        {
+            IDC_ARROW = 32512,
+            IDC_IBEAM = 32513,
+            IDC_WAIT = 32514,
+            IDC_CROSS = 32515,
+            IDC_UPARROW = 32516,
+            IDC_SIZE = 32640,
+            IDC_ICON = 32641,
+            IDC_SIZENWSE = 32642,
+            IDC_SIZENESW = 32643,
+            IDC_SIZEWE = 32644,
+            IDC_SIZENS = 32645,
+            IDC_SIZEALL = 32646,
+            IDC_NO = 32648,
+            IDC_HAND = 32649,
+            IDC_APPSTARTING = 32650,
+            IDC_HELP = 32651
+        }
+
+        public static MouseCursor IShapedCursor = new MouseCursor(IDC_STANDARD_CURSORS.IDC_IBEAM);
+        public static MouseCursor Pointer = new MouseCursor(IDC_STANDARD_CURSORS.IDC_ARROW);
+        public static readonly MouseCursor DefaultAndWait = new MouseCursor(IDC_STANDARD_CURSORS.IDC_APPSTARTING);
+        public static readonly MouseCursor Wait = new MouseCursor(IDC_STANDARD_CURSORS.IDC_WAIT);
 
         private readonly int value;
         private static readonly List<MouseCursor> waitCursors = new List<MouseCursor>();
@@ -19,13 +42,18 @@ namespace TestStack.White.InputDevices
         {
             waitCursors.Add(DefaultAndWait);
             waitCursors.Add(Wait);
-            waitCursors.Add(SilverlightWait);
             waitCursors.AddRange(DynamicWaitCursors());
         }
 
         public MouseCursor(int value)
         {
             this.value = value;
+        }
+
+        private MouseCursor(IDC_STANDARD_CURSORS cursor)
+        {
+            var c = LoadCursor(IntPtr.Zero, cursor);
+            this.value = c.ToInt32();
         }
 
         public static List<MouseCursor> DynamicWaitCursors()


### PR DESCRIPTION
Hi.

I was investigating why White is often very slow to get items (WPF application) and found out that it was waiting inside `Window.HourGlassWait()` method. Adding some debug logging shown such thing:

```
[Debug] 'TestStack.White.UIItems.UIItem' HourGlassWait: current cursor is 65543, waiting again
[Debug] 'TestStack.White.UIItems.UIItem' HourGlassWait: current cursor is 65543, waiting again
[Debug] 'TestStack.White.UIItems.UIItem' HourGlassWait: current cursor is 65543, waiting again
[Debug] 'TestStack.White.UIItems.UIItem' HourGlassWait: current cursor is 65543, waiting again
```

and yet several dozens of such lines after what timeout happened.

[Here](https://github.com/TestStack/White/blob/master/src/TestStack.White/InputDevices/MouseCursor.cs#L12) HCURSOR=65543 is defined as `SilverlightWait`. But we don't use Silverlight at all. Trying to figure out what is happening I've written such piece:

``` csharp
        // this is from http://www.pinvoke.net/default.aspx/user32/LoadCursor.html
        [DllImport("user32.dll")]
        static extern IntPtr LoadCursor(IntPtr hInstance, IDC_STANDARD_CURSORS lpCursorName);

        // this is from http://pinvoke.net/default.aspx/Constants/IDC_.html
        enum IDC_STANDARD_CURSORS
        {
            IDC_ARROW = 32512,
            IDC_IBEAM = 32513,
            IDC_WAIT = 32514,
            IDC_CROSS = 32515,
            IDC_UPARROW = 32516,
            IDC_SIZE = 32640,
            IDC_ICON = 32641,
            IDC_SIZENWSE = 32642,
            IDC_SIZENESW = 32643,
            IDC_SIZEWE = 32644,
            IDC_SIZENS = 32645,
            IDC_SIZEALL = 32646,
            IDC_NO = 32648,
            IDC_HAND = 32649,
            IDC_APPSTARTING = 32650,
            IDC_HELP = 32651
        }

        var values = Enum.GetValues(typeof (IDC_STANDARD_CURSORS)).Cast<IDC_STANDARD_CURSORS>().ToArray();
        foreach (var idcStandardCursor in values)
        {
            var c = LoadCursor(IntPtr.Zero, idcStandardCursor);
            Console.WriteLine("{0} = {1}", idcStandardCursor.ToString(), c.ToInt32());
        }
```

And the result was:

```
IDC_ARROW = 65543
IDC_IBEAM = 65545
IDC_WAIT = 65547
IDC_CROSS = 65549
IDC_UPARROW = 65551
IDC_SIZE = 0
IDC_ICON = 0
IDC_SIZENWSE = 65553
IDC_SIZENESW = 65555
IDC_SIZEWE = 65557
IDC_SIZENS = 65559
IDC_SIZEALL = 65561
IDC_NO = 65563
IDC_HAND = 65571
IDC_APPSTARTING = 65565
IDC_HELP = 65567
```

It seems that in my OS 65543 is precisely "normal" arrow cursor. And `Window.HourGlassWait()` waits until something else found. Not to mention that waiting results in failure.
By the way, other cursors in the [MouseCursor.cs](https://github.com/TestStack/White/blob/master/src/TestStack.White/InputDevices/MouseCursor.cs) are also not coincide with my OS values.

Now, this pull request is more a question then ready-to-merge code, because I don't know what to replace Silverlight values with, so just commented them. But overall this code make unit-tests of White pass on my machine and my real code work much-much faster (I believe that before I was waiting for a timeout on almost each `WaitHourGlass()` call).
