### PR TITLE
Close all windows on Application close, not just main one

### DIFF
--- a/src/TestStack.White/Application.cs
+++ b/src/TestStack.White/Application.cs
@@ -10,6 +10,7 @@ using TestStack.White.Factory;
 using TestStack.White.Sessions;
 using TestStack.White.UIItems.Finders;
 using TestStack.White.UIItems.WindowItems;
+using TestStack.White.WindowsAPI;
 
 namespace TestStack.White
 {
@@ -215,7 +216,10 @@ namespace TestStack.White
                 Process.Dispose();
                 return;
             }
-            Process.CloseMainWindow();
+            foreach (var window in NativeWindow.GetProcessWindows(Process.Id))
+            {
+                window.PostCloseMessage();
+            }
             Process.WaitForExit(5000);
             if (!Process.HasExited)
             {


### PR DESCRIPTION
On Application.Close() instead of closing main window only it is better to close everything we can - there can be more than one window, e.g. in multi-threaded UI case.
