### PR TITLE
Issue155 fixed.

### DIFF
--- a/src/TestStack.White/UIItems/ListViewRow.cs
+++ b/src/TestStack.White/UIItems/ListViewRow.cs
@@ -43,7 +43,8 @@ namespace TestStack.White.UIItems
                         new AutomationSearchCondition(
                             new OrCondition(
                                 AutomationSearchCondition.ByControlType(ControlType.Text).Condition,
-                                AutomationSearchCondition.ByControlType(ControlType.CheckBox).Condition)));
+                                AutomationSearchCondition.ByControlType(ControlType.CheckBox).Condition,
+                                AutomationSearchCondition.ByControlType(ControlType.ComboBox).Condition)));
                 return new ListViewCells(collection, actionListener, header);
             }
         }


### PR DESCRIPTION
The problem is that grid cell contains combobox, but current condition looks only for Text or CheckBox.
So I updated condition, thus combobox inside grid cell can be found.

By the way, this cell's text can't be accessed via Text property.
