### PR TITLE
Issue105 fix. Removed ClearDate from DateTimePicker.

### DIFF
--- a/src/TestStack.White/UIItems/DateTimePicker.cs
+++ b/src/TestStack.White/UIItems/DateTimePicker.cs
@@ -26,16 +26,11 @@ namespace TestStack.White.UIItems
             }
         }
 
-        private void ClearDate()
-        {
-            
-        }
-
         public virtual void SetDate(DateTime? dateTime, DateFormat dateFormat)
         {
             if (dateTime == null)
             {
-                ClearDate();
+                Logger.Warn("DateTime cannot be null, value will not be set");
                 return;
             }
 


### PR DESCRIPTION
The value of Win32 DateTimePicker can not be cleared, so I removed ClearDate method and replaced it with warning.
This doesn't concern WPF DatePicker.
