### PR TITLE
Partial solution for WinForms ComboBox.

### DIFF
--- a/src/TestStack.White/UIItems/ListBoxItems/WinFormComboBox.cs
+++ b/src/TestStack.White/UIItems/ListBoxItems/WinFormComboBox.cs
@@ -1,6 +1,8 @@
 using System.Windows.Automation;
 using TestStack.White.AutomationElementSearch;
+using TestStack.White.UIA;
 using TestStack.White.UIItems.Actions;
+using TestStack.White.UIItems.WPFUIItems;
 
 namespace TestStack.White.UIItems.ListBoxItems
 {
@@ -25,6 +27,31 @@ namespace TestStack.White.UIItems.ListBoxItems
         private TextBox GetTextBox()
         {
             return new TextBox(Finder.Child(AutomationSearchCondition.ByControlType(ControlType.Edit)), actionListener);
+        }
+
+        public override ExpandCollapseState ExpandCollapseState
+        {
+            get
+            {
+                var itemsList = Finder.FindChildRaw(AutomationSearchCondition.ByControlType(ControlType.List));
+                return itemsList == null ? ExpandCollapseState.Collapsed : ExpandCollapseState.Expanded;
+            }
+        }
+
+        public override bool Expand()
+        {
+            if (ExpandCollapseState == ExpandCollapseState.Expanded) return false;
+            var openButton = AutomationElement.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Button));
+            openButton.GetPattern<InvokePattern>().Invoke();
+            return true;
+        }
+
+        public override bool Collapse()
+        {
+            if (ExpandCollapseState == ExpandCollapseState.Collapsed) return false;
+            var openButton = AutomationElement.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Button));
+            openButton.GetPattern<InvokePattern>().Invoke();
+            return true;
         }
     }
 }


### PR DESCRIPTION
For some reason, in UIA v3 ComboBox doesn't expose ExpandCollapsePattern. Instead it has button "Open" which can be clicked. This change abstracts required changes away.
