### PR TITLE
Bugfix: Allow support for screen types with extremely long full type names

### DIFF
--- a/src/TestStack.White.ScreenObjects/ScreenRepository.cs
+++ b/src/TestStack.White.ScreenObjects/ScreenRepository.cs
@@ -107,7 +107,7 @@ namespace TestStack.White.ScreenObjects
 
         private static InitializeOption IdentifiedOption<T>(InitializeOption option)
         {
-            return option.AndIdentifiedBy(typeof (T).FullName);
+            return option.AndIdentifiedBy(typeof (T).GUID.ToString());
         }
 
         private T GetScreen<T>(Window window) where T : AppScreen

--- a/src/TestStack.White.UITests/GenericScreenTypeTest.cs
+++ b/src/TestStack.White.UITests/GenericScreenTypeTest.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using TestStack.White.Factory;
+using TestStack.White.ScreenObjects;
+using TestStack.White.UIItems;
+using TestStack.White.UIItems.Finders;
+using TestStack.White.UIItems.WindowItems;
+
+namespace TestStack.White.UITests
+{
+    public class GenericScreenTypeTest : WhiteTestBase
+    {
+        protected override void ExecuteTestRun(WindowsFramework framework)
+        {
+            var screen = Repository.Get<SomeGenericScreen<int, int>>(MainWindow.Title, InitializeOption.NoCache);
+            screen.MakeWindowItemsMapDirty();
+            Application.ApplicationSession.Save();
+        }
+
+        protected override IEnumerable<WindowsFramework> SupportedFrameworks()
+        {
+            yield return WindowsFramework.WinForms;
+            yield return WindowsFramework.Wpf;
+        }
+
+        private class SomeGenericScreen<T1, T2> : AppScreen
+        {
+            private readonly Window window;
+
+            public SomeGenericScreen(Window window, ScreenRepository screenRepository)
+                : base(window, screenRepository)
+            {
+                this.window = window;
+            }
+
+            public virtual void MakeWindowItemsMapDirty()
+            {
+                window.Get(SearchCriteria.All);
+            }
+        }
+    }
+}

--- a/src/TestStack.White.UITests/TestStack.White.UITests.csproj
+++ b/src/TestStack.White.UITests/TestStack.White.UITests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="ControlTests\ProgressBarTest.cs" />
     <Compile Include="ControlTests\WindowStripControls\StatusBarTest.cs" />
     <Compile Include="ControlTests\WindowStripControls\StatusStripTest.cs" />
+    <Compile Include="GenericScreenTypeTest.cs" />
     <Compile Include="Reporting\One.cs" />
     <Compile Include="Reporting\SessionReportTest.cs" />
     <Compile Include="Reporting\SubFlowsTest.cs" />


### PR DESCRIPTION
Because the screen identifier is later used to build a filename, extremely long type names (such as those from generic types) end up exceeding the 260 char limit on windows and tend to crash a test when disposing a ScreenRepository.

The test is a little ugly (relies on knowledge of the WindowItemsMap internals) as in the current implementation, it's essentially an integration issue between the ID generated by the ScreenRepository and the filename generated in WindowItemsMap.

A couple of approaches that could allow for this issue to be managed at a unit test level;
- Changing the Identifier type on InitializeOption from string to Guid
- Changing the Identifier type on InitializeOption from string to Type
