### PR TITLE
Being able to capture part of the screen (Windows, UIItems, etc.)

### DIFF
--- a/src/TestStack.White.UITests/WhiteTestBase.cs
+++ b/src/TestStack.White.UITests/WhiteTestBase.cs
@@ -80,7 +80,7 @@ namespace TestStack.White.UITests
                     {
                         path2 = testAction.Method.Name + ".png";
                         var filename = Path.Combine(screenshotDir, path2);
-                        new ScreenCapture().CaptureScreenShot().Save(filename, ImageFormat.Png);
+                        Desktop.CaptureScreenshot().Save(filename, ImageFormat.Png);
                         Trace.WriteLine(string.Format("Screenshot taken: {0}", filename));
                     }
                     catch (Exception)

--- a/src/TestStack.White/Desktop.cs
+++ b/src/TestStack.White/Desktop.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Windows;
 using System.Windows.Automation;
 using TestStack.White.AutomationElementSearch;
 using TestStack.White.Factory;
@@ -63,7 +64,29 @@ namespace TestStack.White
         public static Bitmap CaptureScreenshot()
         {
             var screenCapture = new ScreenCapture();
-            return screenCapture.CaptureScreenShot();
+            return screenCapture.CaptureDesktop();
+        }
+
+        /// <summary>
+        /// Captures a screenshot of the provided boundary, and returns the bitmap
+        /// </summary>
+        /// <param name="bounds">Screen rectangle to capture</param>
+        public static Bitmap CaptureScreenshot(Rect bounds)
+        {
+            var screenCapture = new ScreenCapture();
+            return screenCapture.CaptureArea(bounds);
+        }
+
+        /// <summary>
+        /// Takes a screenshot of the provided boundary, and saves it to disk
+        /// </summary>
+        /// <param name="bounds"></param>
+        /// <param name="filename">The fullname of the file (including extension)</param>
+        /// <param name="imageFormat"></param>
+        public static void TakeScreenshot(Rect bounds, string filename, ImageFormat imageFormat)
+        {
+            var bitmap = CaptureScreenshot(bounds);
+            bitmap.Save(filename, imageFormat);            
         }
 
         /// <summary>

--- a/src/TestStack.White/ScreenCapture.cs
+++ b/src/TestStack.White/ScreenCapture.cs
@@ -1,13 +1,18 @@
 using System;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
+using System.Windows;
+using TestStack.White.SystemExtensions;
+using TestStack.White.UIItems.WindowItems;
+using Size = System.Drawing.Size;
 
 namespace TestStack.White
 {
     /// <summary>
     /// Provides functions to capture the entire screen, or a particular window, and save it to a file.
     /// </summary>
-    public class ScreenCapture
+    internal class ScreenCapture
     {
         // This code is a modified version of many similar classes along the same lines. There is no one source I can credit with this class
 
@@ -30,9 +35,10 @@ namespace TestStack.White
         [DllImport("user32.dll")]
         public static extern IntPtr GetWindowDC(IntPtr ptr);
 
-        public virtual Bitmap CaptureScreenShot()
+        public virtual Bitmap CaptureDesktop()
         {
-            var sz = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Size;
+            var bounds = System.Windows.Forms.Screen.PrimaryScreen.Bounds;
+            var sz = bounds.Size;
             var hDesk = GetDesktopWindow();
             var hSrce = GetWindowDC(hDesk);
             var hDest = CreateCompatibleDC(hSrce);
@@ -44,6 +50,19 @@ namespace TestStack.White
             DeleteObject(hBmp);
             DeleteDC(hDest);
             ReleaseDC(hDesk, hSrce);
+
+            return bmp;            
+        }
+
+        public virtual Bitmap CaptureArea(Rect rect)
+        {
+            var rectangle = rect.ToRectangle();
+            var width = rectangle.Right - rectangle.Left;
+            var height = rectangle.Bottom - rectangle.Top;
+            var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            var graphics = Graphics.FromImage(bmp);
+
+            graphics.CopyFromScreen(rectangle.Left, rectangle.Top, 0, 0, new Size(width, height), CopyPixelOperation.SourceCopy);
 
             return bmp;
         }

--- a/src/TestStack.White/SystemExtensions/RectangleExtensions.cs
+++ b/src/TestStack.White/SystemExtensions/RectangleExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Drawing;
+using System.Windows;
+
+namespace TestStack.White.SystemExtensions
+{
+    public static class RectangleExtensions
+    {
+        public static Rect ToRect(this Rectangle rectangle)
+        {
+            return new Rect(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
+        }
+
+        public static Rectangle ToRectangle(this Rect rect)
+        {
+            return new Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
+        }
+    }
+}

--- a/src/TestStack.White/TestStack.White.csproj
+++ b/src/TestStack.White/TestStack.White.csproj
@@ -156,6 +156,7 @@
     <Compile Include="ScreenMap\WindowsAutomationTypesSurrogates.cs" />
     <Compile Include="Span.cs" />
     <Compile Include="SystemExtensions\DoubleX.cs" />
+    <Compile Include="SystemExtensions\RectangleExtensions.cs" />
     <Compile Include="SystemExtensions\TypeExtensions.cs" />
     <Compile Include="UIA\AutomationElementCollectionX.cs" />
     <Compile Include="UIA\AutomationElementX.cs" />


### PR DESCRIPTION
For approval tests to be more concise, you need to get screenshot of certain parts (UIItem) of the application. That's where the screenshot of the whole desktop won't be useful. I have created an overload where you can specify bounds for the screenshot.

Another change is making the screencapture class internal, as the interface to that is through the Desktop object.

Also note that I have taken a different approach to taking the screenshot so it relies only on managed code. Happy to send you another pull request to get rid of the unmanaged codes in ScreenCapture class. 