### PR TITLE
Look for Children Rows in ListViews

### DIFF
--- a/src/TestStack.White/UIItems/ListViewRows.cs
+++ b/src/TestStack.White/UIItems/ListViewRows.cs
@@ -14,7 +14,7 @@ namespace TestStack.White.UIItems
 
         public ListViewRows(AutomationElementFinder finder, ActionListener actionListener, ListViewHeader header)
         {
-            List<AutomationElement> collection = finder.Descendants(AutomationSearchCondition.ByControlType(ControlType.DataItem));
+            List<AutomationElement> collection = finder.Children(AutomationSearchCondition.ByControlType(ControlType.DataItem));
             foreach (AutomationElement element in collection)
                 Add(new ListViewRow(element, actionListener, header));
         }


### PR DESCRIPTION
Instead of collecting all Elements of type DataItem below
a ListView just collect the child DataItem objects.
This prevents wrong Rows if a ListView-Row contains another
ListView.

fixes #261