### PR TITLE
Scrolling by MouseWheel if scroll bar clicking does not work

### DIFF
--- a/src/TestStack.White.UITests/Infrastructure/WindowsConfiguration.cs
+++ b/src/TestStack.White.UITests/Infrastructure/WindowsConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using TestStack.White.Factory;
@@ -21,7 +22,9 @@ namespace TestStack.White.UITests.Infrastructure
 
         public override Application LaunchApplication()
         {
-            var app = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), ApplicationExePath());
+            // use Codebase so that the tests work also with shadowing enabled
+            var codeBase = new Uri(Assembly.GetExecutingAssembly().CodeBase);
+            var app = Path.Combine(Path.GetDirectoryName(codeBase.LocalPath), ApplicationExePath());
             var processStartInfo = new ProcessStartInfo
             {
                 FileName = app,

--- a/src/TestStack.White.UITests/Scenarios/Win32Tests.cs
+++ b/src/TestStack.White.UITests/Scenarios/Win32Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using TestStack.White.Factory;
 using TestStack.White.UIItems;
@@ -20,14 +21,26 @@ namespace TestStack.White.UITests.Scenarios
         [Fact]
         public void NotepadTests()
         {
+            string windowTitle = "Untitled - Notepad";
+            string fontMenuItemShortcuts = "of";
+            string fontDialogTitle = "Font";
+
+            var lang = CultureInfo.InstalledUICulture.Name;
+            if (lang.StartsWith("de"))
+            {
+                windowTitle = "Unbenannt - Editor";
+                fontMenuItemShortcuts = "os";
+                fontDialogTitle = "Schriftart";
+            }
+
             using (var app = Application.Launch(Notepad))
-            using (var window = app.GetWindow("Untitled - Notepad"))
+            using (var window = app.GetWindow(windowTitle))
             {
                 window.Keyboard.PressSpecialKey(KeyboardInput.SpecialKeys.ALT);
-                window.Keyboard.Enter("o");
-                window.Keyboard.Enter("f");
+                foreach (char c in fontMenuItemShortcuts)
+                    window.Keyboard.Enter(c.ToString());
 
-                using (var modalWindow = window.ModalWindow("Font"))
+                using (var modalWindow = window.ModalWindow(fontDialogTitle))
                 {
                     Assert.NotNull(modalWindow);
                 }
@@ -37,15 +50,27 @@ namespace TestStack.White.UITests.Scenarios
         [Fact]
         public void InternetExplorerTests()
         {
+            string toolTipText = "Tools (Alt+X)";
+            string optionsMenuItem = "Internet Options";
+            string optionsDialogTitle = "Internet Options";
+
+            var lang = CultureInfo.InstalledUICulture.Name;
+            if (lang.StartsWith("de"))
+            {
+                toolTipText = "Extras (Alt+X)";
+                optionsMenuItem = "Internetoptionen";
+                optionsDialogTitle = "Internetoptionen";
+            }
+
             using (var app = Application.Launch(InternetExplorer))
             using (var window = app.GetWindows().Single())
             {
                 var button = window.Get<Button>(SearchCriteria.ByAutomationId("Item 3"));
                 //check if we can get a win32 tooltip
-                Assert.Equal("Tools (Alt+X)", window.GetToolTipOn(button).Text);
+                Assert.Equal(toolTipText, window.GetToolTipOn(button).Text);
                 button.Click();
-                window.PopupMenu("Internet options").Click();
-                using (var internetOptions = window.ModalWindow("Internet Options"))
+                window.PopupMenu(optionsMenuItem).Click();
+                using (var internetOptions = window.ModalWindow(optionsDialogTitle))
                 {
                     var textBox = internetOptions.Get<TextBox>(SearchCriteria.ByAutomationId("1487"));
 
@@ -59,24 +84,47 @@ namespace TestStack.White.UITests.Scenarios
         [Fact]
         public void CalculatorTests()
         {
+            string windowTitle = "Calculator";
+            string menuBarName = "Application";
+            string editMenuItem = "Edit";
+            string copyMenuItem = "Copy";
+            string viewMenuItem = "View";
+            string basicMenuItem = "Basic";
+            string dateCalcAccelerator = "E";
+            string dateCalcComboBoxItem = "Calculate the difference between two dates";
+
+            var lang = CultureInfo.InstalledUICulture.Name;
+            if (lang.StartsWith("de"))
+            {
+                windowTitle = "Rechner";
+                menuBarName = "Anwendung";
+                editMenuItem = "Bearbeiten";
+                copyMenuItem = "Kopieren";
+                viewMenuItem = "Ansicht";
+                basicMenuItem = "Basismodus";
+                dateCalcAccelerator = "E";
+                dateCalcComboBoxItem = "Differenz zwischen zwei Datumsangaben berechnen";
+            }
+
+
             //strat process for the above exe file location
             var psi = new ProcessStartInfo(ExeSourceFile);
             // launch the process through white application
             using (var application = Application.AttachOrLaunch(psi))
-            using (var mainWindow = application.GetWindow(SearchCriteria.ByText("Calculator"), InitializeOption.NoCache))
+            using (var mainWindow = application.GetWindow(SearchCriteria.ByText(windowTitle), InitializeOption.NoCache))
             {
                 // Verify can click on menu twice
-                var menuBar = mainWindow.Get<MenuBar>(SearchCriteria.ByText("Application"));
-                menuBar.MenuItem("Edit", "Copy").Click();
-                menuBar.MenuItem("Edit", "Copy").Click();
+                var menuBar = mainWindow.Get<MenuBar>(SearchCriteria.ByText(menuBarName));
+                menuBar.MenuItem(editMenuItem, copyMenuItem).Click();
+                menuBar.MenuItem(editMenuItem, copyMenuItem).Click();
 
                 mainWindow.Keyboard.HoldKey(KeyboardInput.SpecialKeys.CONTROL);
-                mainWindow.Keyboard.Enter("E");
+                mainWindow.Keyboard.Enter(dateCalcAccelerator);
                 mainWindow.Keyboard.LeaveKey(KeyboardInput.SpecialKeys.CONTROL);
 
                 //On Date window find the difference between dates.
                 //Set value into combobox
-                mainWindow.Get<ComboBox>(SearchCriteria.ByAutomationId("4003")).Select("Calculate the difference between two dates");
+                mainWindow.Get<ComboBox>(SearchCriteria.ByAutomationId("4003")).Select(dateCalcComboBoxItem);
                 //Click on Calculate button
                 mainWindow.Get<Button>(SearchCriteria.ByAutomationId("4009")).Click();
 
@@ -84,9 +132,9 @@ namespace TestStack.White.UITests.Scenarios
                 mainWindow.Keyboard.PressSpecialKey(KeyboardInput.SpecialKeys.F4);
                 mainWindow.Keyboard.LeaveKey(KeyboardInput.SpecialKeys.CONTROL);
 
-                var menuView = mainWindow.Get<Menu>(SearchCriteria.ByText("View"));
+                var menuView = mainWindow.Get<Menu>(SearchCriteria.ByText(viewMenuItem));
                 menuView.Click();
-                var menuViewBasic = mainWindow.Get<Menu>(SearchCriteria.ByText("Basic"));
+                var menuViewBasic = mainWindow.Get<Menu>(SearchCriteria.ByText(basicMenuItem));
                 menuViewBasic.Click();
 
                 PerformSummationOnCalculator(mainWindow);

--- a/src/TestStack.White.UITests/WhiteTestBase.cs
+++ b/src/TestStack.White.UITests/WhiteTestBase.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Castle.Core.Logging;
 using TestStack.White.Configuration;
 using TestStack.White.InputDevices;
@@ -30,6 +32,8 @@ namespace TestStack.White.UITests
             screenshotDir = "c:\\FailedTestsScreenshots";
             if (!Directory.Exists(screenshotDir))
                 Directory.CreateDirectory(screenshotDir);
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
         }
 
         protected Window MainWindow { get; private set; }

--- a/src/TestStack.White/InputDevices/Mouse.cs
+++ b/src/TestStack.White/InputDevices/Mouse.cs
@@ -139,6 +139,11 @@ namespace TestStack.White.InputDevices
             ActionPerformed(actionListener);
         }
 
+        public virtual void Wheel(int delta)
+        {
+            SendInput(InputFactory.Mouse(new MouseInput(120 * delta, WindowsConstants.MOUSEEVENTF_WHEEL, GetMessageExtraInfo())));
+        }
+
         private static void SendInput(Input input)
         {
             // Added check for 32/64 bit  
@@ -182,6 +187,13 @@ namespace TestStack.White.InputDevices
         {
             Location = point;
             Click();
+            ActionPerformed(actionListener);
+        }
+
+        public virtual void Wheel(Point point, int delta, ActionListener actionListener)
+        {
+            Location = point;
+            Wheel(delta);
             ActionPerformed(actionListener);
         }
 

--- a/src/TestStack.White/UIItems/Scrolling/ScreenItem.cs
+++ b/src/TestStack.White/UIItems/Scrolling/ScreenItem.cs
@@ -31,7 +31,38 @@ namespace TestStack.White.UIItems.Scrolling
                 return;
             }
 
-            if (verticalSpanProvider is UIItem)
+            if (verticalScroll != null && verticalScroll.IsScrollable)
+            {
+                logger.DebugFormat("Trying to make visible {0}, item's bounds are {1} and parent's span is {2}", uiItem, uiItem.Bounds, verticalSpan);
+
+                if (verticalScroll.IsNotMinimum)
+                {
+                    verticalScroll.SetToMinimum();
+                    verticalSpan = verticalSpanProvider.VerticalSpan;
+                    logger.DebugFormat("Scroll Position set to minimum value.");
+                }
+
+                if (verticalSpan.Contains(uiItem.Bounds))
+                {
+                    logger.DebugFormat("UIItem ({0}) whose bounds are ({1}) is within bounds of parent whose vertical span is {2}", uiItem,
+                                                     uiItem.Bounds, verticalSpan);
+                    return;
+                }
+
+                var success = Retry.For(
+                    () =>
+                    {
+                        verticalScroll.ScrollDownLarge();
+                        var bounds = uiItem.Bounds;
+                        const string messageFormat = "Trying to make {0} visible, item's bounds are {1} and parent's span is {2}";
+                        logger.DebugFormat(messageFormat, uiItem, bounds, verticalSpan);
+                        return verticalSpan.Contains(bounds);
+                    }, CoreAppXmlConfiguration.Instance.BusyTimeout(), TimeSpan.FromMilliseconds(0));
+
+                if (!success)
+                    throw new UIActionException(string.Format("Could not make the {0} visible{1}", uiItem, Constants.BusyMessage));
+            }
+            else if (verticalSpanProvider is UIItem)
             {
                 var containerUiItem = (UIItem)verticalSpanProvider;
 
@@ -44,26 +75,6 @@ namespace TestStack.White.UIItems.Scrolling
                             containerUiItem.MouseWheel(1);
                         else
                             containerUiItem.MouseWheel(-1);
-                        var bounds = uiItem.Bounds;
-                        const string messageFormat = "Trying to make {0} visible, item's bounds are {1} and parent's span is {2}";
-                        logger.DebugFormat(messageFormat, uiItem, bounds, verticalSpan);
-                        return verticalSpan.Contains(bounds);
-                    }, CoreAppXmlConfiguration.Instance.BusyTimeout(), TimeSpan.FromMilliseconds(0));
-
-                if (!success)
-                    throw new UIActionException(string.Format("Could not make the {0} visible{1}", uiItem, Constants.BusyMessage));
-            }
-            else if (verticalScroll != null && verticalScroll.IsScrollable)
-            {
-                logger.DebugFormat("Trying to make visible {0}, item's bounds are {1} and parent's span is {2}", uiItem, uiItem.Bounds, verticalSpan);
-
-                var success = Retry.For(
-                    () =>
-                    {
-                        if (uiItem.Bounds.Top + uiItem.Bounds.Bottom < verticalScroll.Bounds.Top + verticalScroll.Bounds.Bottom)
-                            verticalScroll.ScrollUpLarge();
-                        else
-                            verticalScroll.ScrollDownLarge();
                         var bounds = uiItem.Bounds;
                         const string messageFormat = "Trying to make {0} visible, item's bounds are {1} and parent's span is {2}";
                         logger.DebugFormat(messageFormat, uiItem, bounds, verticalSpan);

--- a/src/TestStack.White/UIItems/TableItems/TableVerticalScrollBar.cs
+++ b/src/TestStack.White/UIItems/TableItems/TableVerticalScrollBar.cs
@@ -19,12 +19,12 @@ namespace TestStack.White.UIItems.TableItems
 
         public virtual void ScrollUp()
         {
-            mouse.Click(Bounds.ImmediateInteriorNorth(), actionListener);
+            mouse.Wheel(Bounds.Center(), 1, actionListener);
         }
 
         public virtual void ScrollDown()
         {
-            mouse.Click(Bounds.ImmediateInteriorSouth(), actionListener);
+            mouse.Wheel(Bounds.Center(), -1, actionListener);
         }
 
         public virtual void ScrollUpLarge()

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -275,6 +275,15 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
+        /// Performs mouse wheel at the center of this item
+        /// </summary>
+        public virtual void MouseWheel(int delta)
+        {
+            actionListener.ActionPerforming(this);
+            PerformIfValid(() => mouse.Wheel(Bounds.Center(), delta, actionListener));
+        }
+
+        /// <summary>
         /// Perform keyboard action on this UIItem
         /// </summary>
         /// <param name="key"></param>

--- a/src/TestStack.White/WindowsAPI/WindowPlacement.cs
+++ b/src/TestStack.White/WindowsAPI/WindowPlacement.cs
@@ -49,6 +49,16 @@ namespace TestStack.White.WindowsAPI
         private readonly int time;
         private readonly IntPtr dwExtraInfo;
 
+        public MouseInput(int mouseData, int dwFlags, IntPtr dwExtraInfo)
+        {
+            this.dwFlags = dwFlags;
+            this.dwExtraInfo = dwExtraInfo;
+            dx = 0;
+            dy = 0;
+            time = 0;
+            this.mouseData = mouseData;
+        }
+
         public MouseInput(int dwFlags, IntPtr dwExtraInfo)
         {
             this.dwFlags = dwFlags;


### PR DESCRIPTION
I would like to contribute a change affecting the way ScreenItem.MakeVisible works. 
The motivation is that WinForms controls running within Visual Studio (e.g. in a VS package) get modified scroll bars which do not have the LargeChangeButtons and thus cannot be scrolled by ScreenItem.MakeVisible. The changed code uses mouse wheel scrolling in this case.

In addition, I did some small changes to TestStack.White.UITests to allow running the tests with shadow copying and on non-english OS.