### PR TITLE
Added IsSelected Property to ListViewCell

### DIFF
--- a/src/TestStack.White.UITests/ControlTests/DataGridTests.cs
+++ b/src/TestStack.White.UITests/ControlTests/DataGridTests.cs
@@ -59,6 +59,19 @@ namespace TestStack.White.UITests.ControlTests
         }
 
         [Test]
+        public void IsCellSelectedWpfTest()
+        {
+            if (Framework != WindowsFramework.Wpf)
+            {
+                Assert.Ignore();
+            }
+            var rows = dataGridWpfUnderTest.Rows;
+            rows[1].Cells[1].Click();
+            Assert.That(rows[1].Cells[1].IsSelected, Is.True);
+            Assert.That(rows[1].Cells[2].IsSelected, Is.False);
+        }
+
+        [Test]
         public void CanGetAllItemsWinformsTest()
         {
             if (Framework != WindowsFramework.WinForms)

--- a/src/TestStack.White/Factory/ListViewCellFactory.cs
+++ b/src/TestStack.White/Factory/ListViewCellFactory.cs
@@ -1,4 +1,5 @@
 using System.Windows.Automation;
+using TestStack.White.AutomationElementSearch;
 using TestStack.White.UIItems;
 using TestStack.White.UIItems.Actions;
 
@@ -6,9 +7,19 @@ namespace TestStack.White.Factory
 {
     public class ListViewCellFactory : UIItemFactory
     {
+        private AutomationElementFinder finder;
+
         public virtual IUIItem Create(AutomationElement automationElement, ActionListener actionListener)
         {
-            return new ListViewCell(automationElement, actionListener);
+            finder = new AutomationElementFinder(automationElement);
+            var child = finder.Child(
+                new AutomationSearchCondition(
+                    new OrCondition(AutomationSearchCondition.ByControlType(ControlType.Text).Condition,
+                                AutomationSearchCondition.ByControlType(ControlType.CheckBox).Condition,
+                                AutomationSearchCondition.ByControlType(ControlType.ComboBox).Condition
+                        )));
+
+            return new ListViewCell(child, automationElement, actionListener);
         }
     }
 }

--- a/src/TestStack.White/UIItems/ListViewCell.cs
+++ b/src/TestStack.White/UIItems/ListViewCell.cs
@@ -5,7 +5,21 @@ namespace TestStack.White.UIItems
 {
     public class ListViewCell : Label
     {
+        private readonly AutomationElement cell;
+
         protected ListViewCell() {}
+
         public ListViewCell(AutomationElement automationElement, ActionListener actionListener) : base(automationElement, actionListener) {}
+
+        public ListViewCell(AutomationElement automationElement, AutomationElement cell, ActionListener actionListener)
+            : base(automationElement, actionListener)
+        {
+            this.cell = cell;
+        }
+
+        public bool IsSelected
+        {
+            get { return cell.Current.HasKeyboardFocus; }
+        }
     }
 }

--- a/src/TestStack.White/UIItems/ListViewCell.cs
+++ b/src/TestStack.White/UIItems/ListViewCell.cs
@@ -17,8 +17,11 @@ namespace TestStack.White.UIItems
             this.cell = cell;
         }
 
+
         public bool IsSelected
         {
+            //The reason is selected is using the HasKeyboardFocus property instead of a selection item pattern is because the cells do not support the selection item pattern.
+            //If this ever changes this should be switched to use the selection item pattern.
             get { return cell.Current.HasKeyboardFocus; }
         }
     }

--- a/src/TestStack.White/UIItems/ListViewRow.cs
+++ b/src/TestStack.White/UIItems/ListViewRow.cs
@@ -46,12 +46,7 @@ namespace TestStack.White.UIItems
             get
             {
                 actionListener.ActionPerforming(this);
-                var collection = finder.Descendants(
-                        new AutomationSearchCondition(
-                            new OrCondition(
-                                AutomationSearchCondition.ByControlType(ControlType.Text).Condition,
-                                AutomationSearchCondition.ByControlType(ControlType.CheckBox).Condition,
-                                AutomationSearchCondition.ByControlType(ControlType.ComboBox).Condition)));
+                var collection = finder.Descendants(AutomationSearchCondition.ByClassName("DataGridCell"));
                 return new ListViewCells(collection, actionListener, header);
             }
         }


### PR DESCRIPTION
Added the ability to get whether a ListViewCell is focused independent
of the Text, Combobox or Checkbox that the ListViewCell contains. This
required me to change the search criteria in ListViewRow and in
ListViewCellFactory so I could get a list of DataGridItems then get
their children when creating the ListViewCell. I also had to store a seperate cell automationelement on the ListViewCell and then pass the child control down through the base.