### PR TITLE
Extending Extention Methods for WPFUiItem

### DIFF
--- a/src/TestStack.White/UIItems/IUIItem.cs
+++ b/src/TestStack.White/UIItems/IUIItem.cs
@@ -14,8 +14,8 @@ namespace TestStack.White.UIItems
     public interface IUIItem : IActionListener
     {
         /// <summary>
-        ///     Should be used only if white doesn't support the feature you are looking for.
-        ///     Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
+        /// Should be used only if white doesn't support the feature you are looking for.
+        /// Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
         /// </summary>
         AutomationElement AutomationElement { get; }
 
@@ -41,15 +41,15 @@ namespace TestStack.White.UIItems
         void Focus();
 
         /// <summary>
-        ///     An alternative to use instead of Focus, might sometimes be more reliable
+        /// An alternative to use instead of Focus, might sometimes be more reliable
         /// </summary>
         void SetForeground();
 
         void Visit(IWindowControlVisitor windowControlVisitor);
 
         /// <summary>
-        ///     Provides the Error on this UIItem. This would return Error object when this item has ErrorProvider displayed next
-        ///     to it.
+        /// Provides the Error on this UIItem. 
+        /// This would return Error object when this item has ErrorProvider displayed next to it.
         /// </summary>
         /// <param name="window"></param>
         /// <returns></returns>
@@ -58,17 +58,17 @@ namespace TestStack.White.UIItems
         bool NameMatches(string text);
 
         /// <summary>
-        ///     Performs mouse click at the center of this item
+        /// Performs mouse click at the center of this item
         /// </summary>
         void Click();
 
         /// <summary>
-        ///     Performs mouse double click at the center of this item
+        /// Performs mouse double click at the center of this item
         /// </summary>
         void DoubleClick();
 
         /// <summary>
-        ///     Perform keyboard action on this UIItem
+        ///Perform keyboard action on this UIItem
         /// </summary>
         /// <param name="key"></param>
         void KeyIn(KeyboardInput.SpecialKeys key);
@@ -78,12 +78,12 @@ namespace TestStack.White.UIItems
         string ToString();
 
         /// <summary>
-        ///     Internal to white and intended to be used for white recording
+        /// Internal to white and intended to be used for white recording
         /// </summary>
         void UnHookEvents();
 
         /// <summary>
-        ///     Internal to white and intended to be used for white recording
+        /// Internal to white and intended to be used for white recording
         /// </summary>
         /// <param name="eventListener"></param>
         void HookEvents(UIItemEventListener eventListener);
@@ -92,13 +92,13 @@ namespace TestStack.White.UIItems
         void LogStructure();
 
         /// <summary>
-        ///     Uses the Raw View provided by UIAutomation to find elements within this UIItem. RawView sometimes contains extra
-        ///     AutomationElements. This is internal to
-        ///     white although made public. Should be used only if the standard approaches dont work. Also if you end up using it
-        ///     please raise an issue
-        ///     so that it can be fixed.
-        ///     Please understand that calling this method on any UIItem which has a lot of child AutomationElements might result
-        ///     in very bad performance.
+        /// Uses the Raw View provided by UIAutomation to find elements within this UIItem. 
+        /// RawView sometimes contains extra AutomationElements. 
+        /// This is internal to white although made public. 
+        /// Should be used only if the standard approaches dont work. 
+        /// Also if you end up using it please raise an issue so that it can be fixed.
+        /// Please understand that calling this method on any UIItem,
+        /// which has a lot of child AutomationElements might result in very bad performance.
         /// </summary>
         /// <param name="searchCriteria"></param>
         /// <returns>null or found AutomationElement</returns>
@@ -110,7 +110,7 @@ namespace TestStack.White.UIItems
         void DrawHighlight(Color color);
 
         /// <summary>
-        ///     Captures an image of the element
+        /// Captures an image of the element
         /// </summary>
         Bitmap Capture();
     }

--- a/src/TestStack.White/UIItems/IUIItem.cs
+++ b/src/TestStack.White/UIItems/IUIItem.cs
@@ -14,10 +14,11 @@ namespace TestStack.White.UIItems
     public interface IUIItem : IActionListener
     {
         /// <summary>
-        /// Should be used only if white doesn't support the feature you are looking for.
-        /// Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
+        ///     Should be used only if white doesn't support the feature you are looking for.
+        ///     Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
         /// </summary>
         AutomationElement AutomationElement { get; }
+
         bool Enabled { get; }
         WindowsFramework Framework { get; }
         Point Location { get; }
@@ -38,14 +39,17 @@ namespace TestStack.White.UIItems
         void RightClickAt(Point point);
         void RightClick();
         void Focus();
+
         /// <summary>
-        /// An alternative to use instead of Focus, might sometimes be more reliable
+        ///     An alternative to use instead of Focus, might sometimes be more reliable
         /// </summary>
         void SetForeground();
+
         void Visit(IWindowControlVisitor windowControlVisitor);
 
         /// <summary>
-        /// Provides the Error on this UIItem. This would return Error object when this item has ErrorProvider displayed next to it.
+        ///     Provides the Error on this UIItem. This would return Error object when this item has ErrorProvider displayed next
+        ///     to it.
         /// </summary>
         /// <param name="window"></param>
         /// <returns></returns>
@@ -54,17 +58,17 @@ namespace TestStack.White.UIItems
         bool NameMatches(string text);
 
         /// <summary>
-        /// Performs mouse click at the center of this item
+        ///     Performs mouse click at the center of this item
         /// </summary>
         void Click();
 
         /// <summary>
-        /// Performs mouse double click at the center of this item
+        ///     Performs mouse double click at the center of this item
         /// </summary>
         void DoubleClick();
 
         /// <summary>
-        /// Perform keyboard action on this UIItem
+        ///     Perform keyboard action on this UIItem
         /// </summary>
         /// <param name="key"></param>
         void KeyIn(KeyboardInput.SpecialKeys key);
@@ -74,12 +78,12 @@ namespace TestStack.White.UIItems
         string ToString();
 
         /// <summary>
-        /// Internal to white and intended to be used for white recording
+        ///     Internal to white and intended to be used for white recording
         /// </summary>
         void UnHookEvents();
 
         /// <summary>
-        /// Internal to white and intended to be used for white recording
+        ///     Internal to white and intended to be used for white recording
         /// </summary>
         /// <param name="eventListener"></param>
         void HookEvents(UIItemEventListener eventListener);
@@ -88,10 +92,13 @@ namespace TestStack.White.UIItems
         void LogStructure();
 
         /// <summary>
-        /// Uses the Raw View provided by UIAutomation to find elements within this UIItem. RawView sometimes contains extra AutomationElements. This is internal to 
-        /// white although made public. Should be used only if the standard approaches dont work. Also if you end up using it please raise an issue
-        /// so that it can be fixed.
-        /// Please understand that calling this method on any UIItem which has a lot of child AutomationElements might result in very bad performance.
+        ///     Uses the Raw View provided by UIAutomation to find elements within this UIItem. RawView sometimes contains extra
+        ///     AutomationElements. This is internal to
+        ///     white although made public. Should be used only if the standard approaches dont work. Also if you end up using it
+        ///     please raise an issue
+        ///     so that it can be fixed.
+        ///     Please understand that calling this method on any UIItem which has a lot of child AutomationElements might result
+        ///     in very bad performance.
         /// </summary>
         /// <param name="searchCriteria"></param>
         /// <returns>null or found AutomationElement</returns>
@@ -103,7 +110,7 @@ namespace TestStack.White.UIItems
         void DrawHighlight(Color color);
 
         /// <summary>
-        /// Captures an image of the element
+        ///     Captures an image of the element
         /// </summary>
         Bitmap Capture();
     }

--- a/src/TestStack.White/UIItems/IUIItemContainer.cs
+++ b/src/TestStack.White/UIItems/IUIItemContainer.cs
@@ -1,17 +1,30 @@
+using System;
 using TestStack.White.UIItems.Finders;
 
 namespace TestStack.White.UIItems
 {
     public interface IUIItemContainer : IUIItem
     {
+        /// <summary>
+        ///     <see cref="ToolTip" /> for the UI Item
+        /// </summary>
         ToolTip ToolTip { get; }
-        ToolTip GetToolTipOn(UIItem uiItem);
-        IUIItem[] GetMultiple(SearchCriteria criteria);
 
         /// <summary>
-        /// Finds UIItem which matches specified type. Useful for non managed applications where controls are not identified by AutomationId, like in 
-        /// Managed applications. In case of multiple items of this type the first one found would be returned which cannot be guaranteed to be the same 
-        /// across multiple invocations.
+        ///     <see cref="ToolTip" /> for a specific UI Item
+        /// </summary>
+        /// <param name="uiItem">UI Item to focus in order to get the corresponding ToolTip</param>
+        /// <returns>The <see cref="ToolTip" /> belonging to the specified UI Item</returns>
+        ToolTip GetToolTipOn(IUIItem uiItem);
+
+        #region Get UI Item
+
+        /// <summary>
+        ///     Finds UIItem which matches specified type. Useful for non managed applications where controls are not identified by
+        ///     AutomationId, like in
+        ///     Managed applications. In case of multiple items of this type the first one found would be returned which cannot be
+        ///     guaranteed to be the same
+        ///     across multiple invocations.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <returns>First item of supplied type</returns>
@@ -20,24 +33,28 @@ namespace TestStack.White.UIItems
         T Get<T>() where T : IUIItem;
 
         /// <summary>
-        /// Finds UIItem which matches specified type and identification. 
-        /// In case of multiple items of this type the first one found would be returned which cannot be guaranteed to be the same across multiple 
-        /// invocations. For managed applications this is name given to controls in the application code.
-        /// For unmanaged applications this is text of the control or label next to it if it doesn't have well defined text.
-        /// <!--e.g. TextBox doesn't have any predefined text of its own as it can be changed at runtime by user, hence is identified by the label next to it.
+        ///     Finds UIItem which matches specified type and identification.
+        ///     In case of multiple items of this type the first one found would be returned which cannot be guaranteed to be the
+        ///     same across multiple
+        ///     invocations. For managed applications this is name given to controls in the application code.
+        ///     For unmanaged applications this is text of the control or label next to it if it doesn't have well defined text.
+        ///     <!--e.g. TextBox doesn't have any predefined text of its own as it can be changed at runtime by user, hence is identified by the label next to it.
         /// If there is no label then Get<T> or Get<T>(SearchCriteria) method can be used.-->
         /// </summary>
         /// <typeparam name="T">IUIItem implementation</typeparam>
-        /// <param name="primaryIdentification">For managed application this is the name provided in application code and unmanaged application this is 
-        /// the text or label next to it based identification</param>
+        /// <param name="primaryIdentification">
+        ///     For managed application this is the name provided in application code and unmanaged application this is
+        ///     the text or label next to it based identification
+        /// </param>
         /// <returns>First item of supplied type and identification</returns>
         /// <exception cref="AutomationException">when item not found</exception>
         /// <exception cref="WhiteException">when any errors occured during search</exception>
         T Get<T>(string primaryIdentification) where T : IUIItem;
 
         /// <summary>
-        /// Finds UIItem which matches specified type and searchCriteria. Type supplied need not be supplied again in SearchCondition.
-        /// <!--e.g. in Get<Button>(SearchCriteria.ByAutomationId("OK").ByControlType(typeof(Button)).Indexed(1) the ByControlType(typeof(Button)) part 
+        ///     Finds UIItem which matches specified type and searchCriteria. Type supplied need not be supplied again in
+        ///     SearchCondition.
+        ///     <!--e.g. in Get<Button>(SearchCriteria.ByAutomationId("OK").ByControlType(typeof(Button)).Indexed(1) the ByControlType(typeof(Button)) part 
         /// is redundant. Look at documentation of SearchCriteria for details on it.-->
         /// </summary>
         /// <code>
@@ -50,12 +67,100 @@ namespace TestStack.White.UIItems
         T Get<T>(SearchCriteria searchCriteria) where T : IUIItem;
 
         /// <summary>
-        /// Finds UIItem which matches specified type and searchCriteria using the default BusyTimeout. Look at documentation of SearchCriteria for details on it.
+        ///     Finds UIItem which matches specified searchCriteria using the default BusyTimeout. Look at documentation
+        ///     of SearchCriteria for details on it.
         /// </summary>
         /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
         /// <returns>First items matching the criteria</returns>
         /// <exception cref="AutomationException">when item not found</exception>
         /// <exception cref="WhiteException">when any errors occured during search</exception>
         IUIItem Get(SearchCriteria searchCriteria);
+
+        /// <summary>
+        ///     Finds UIItem which matches specified type and searchCriteria. Look at documentation of SearchCriteria for details
+        ///     on it.
+        /// </summary>
+        /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
+        /// <param name="busyTimeout">Time to wait for item to come on-screen before returning off-screen element, if found.</param>
+        /// <returns>First items matching the criteria</returns>
+        /// <exception cref="AutomationException">when item not found</exception>
+        /// <exception cref="WhiteException">when any errors occured during search</exception>
+        IUIItem Get(SearchCriteria searchCriteria, TimeSpan busyTimeout);
+
+        #endregion
+
+        #region Get UI Items
+
+        /// <summary>
+        ///     Finds all UIItems using the default BusyTimeout. 
+        /// </summary>
+        /// <returns>Array of all <see cref="IUIItem"/> that can be found</returns>
+        /// <exception cref="AutomationException">when item not found</exception>
+        /// <exception cref="WhiteException">when any errors occured during search</exception>
+        IUIItem[] GetMultiple();
+
+        /// <summary>
+        ///     Finds UIItems which matche a specified searchCriteria using the default BusyTimeout. 
+        ///     Look at documentation of SearchCriteria for details on it.
+        /// </summary>
+        /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
+        /// <returns>Array of <see cref="IUIItem"/> matching the criteria</returns>
+        /// <exception cref="AutomationException">when item not found</exception>
+        /// <exception cref="WhiteException">when any errors occured during search</exception>
+        IUIItem[] GetMultiple(SearchCriteria searchCriteria);
+
+        /// <summary>
+        ///     Finds all UIItems of Type T using the default BusyTimeout. 
+        /// </summary>
+        /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
+        /// <returns>An array of Items of T</returns>
+        T[] GetMultiple<T>() where T : IUIItem;
+
+        /// <summary>
+        ///     Finds all UIItems of type T and adhering to a specific Search Criteria using the default BusyTimeout. 
+        ///     Look at documentation of SearchCriteria for details on it.
+        /// </summary>
+        /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
+        /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
+        /// <returns>An array of Items of T</returns>
+        T[] GetMultiple<T>(SearchCriteria searchCriteria) where T : IUIItem;
+
+        #endregion
+
+        #region UI Item Exists
+
+        /// <summary>
+        ///     Checks if an UIItem which matches specified type exists.
+        /// </summary>
+        /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
+        bool Exists<T>() where T : IUIItem;
+
+        /// <summary>
+        ///     Checks if an UIItem which matches specified type exists.
+        /// </summary>
+        /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
+        /// <param name="primaryIdentification">
+        ///     For managed application this is the name provided in application code and unmanaged application this is
+        ///     the text or label next to it based identification
+        /// </param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
+        bool Exists<T>(string primaryIdentification) where T : IUIItem;
+
+        /// <summary>
+        ///     Checks if an UIItem which matches specified type exists.
+        /// </summary>
+        /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
+        /// <param name="searchCriteria">Criteria provided to search UIItem</param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
+        bool Exists<T>(SearchCriteria searchCriteria) where T : IUIItem;
+
+        /// <summary>
+        ///     Checks if an UIItem which matches specified search criteria exists.
+        /// <param name="searchCriteria">Criteria provided to search UIItem</param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
+        bool Exists(SearchCriteria searchCriteria);
+
+        #endregion
     }
 }

--- a/src/TestStack.White/UIItems/IUIItemContainer.cs
+++ b/src/TestStack.White/UIItems/IUIItemContainer.cs
@@ -6,12 +6,12 @@ namespace TestStack.White.UIItems
     public interface IUIItemContainer : IUIItem
     {
         /// <summary>
-        ///     <see cref="ToolTip" /> for the UI Item
+        /// <see cref="ToolTip" /> for the UI Item
         /// </summary>
         ToolTip ToolTip { get; }
 
         /// <summary>
-        ///     <see cref="ToolTip" /> for a specific UI Item
+        /// <see cref="ToolTip" /> for a specific UI Item
         /// </summary>
         /// <param name="uiItem">UI Item to focus in order to get the corresponding ToolTip</param>
         /// <returns>The <see cref="ToolTip" /> belonging to the specified UI Item</returns>
@@ -20,11 +20,11 @@ namespace TestStack.White.UIItems
         #region Get UI Item
 
         /// <summary>
-        ///     Finds UIItem which matches specified type. Useful for non managed applications where controls are not identified by
-        ///     AutomationId, like in
-        ///     Managed applications. In case of multiple items of this type the first one found would be returned which cannot be
-        ///     guaranteed to be the same
-        ///     across multiple invocations.
+        /// Finds UIItem which matches specified type. 
+        /// Useful for non managed applications where controls are not identified by AutomationId, 
+        /// like in Managed applications. 
+        /// In case of multiple items of this type the first one found would be returned,
+        /// which cannot be guaranteed to be the same across multiple invocations.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <returns>First item of supplied type</returns>
@@ -33,18 +33,18 @@ namespace TestStack.White.UIItems
         T Get<T>() where T : IUIItem;
 
         /// <summary>
-        ///     Finds UIItem which matches specified type and identification.
-        ///     In case of multiple items of this type the first one found would be returned which cannot be guaranteed to be the
-        ///     same across multiple
-        ///     invocations. For managed applications this is name given to controls in the application code.
-        ///     For unmanaged applications this is text of the control or label next to it if it doesn't have well defined text.
-        ///     <!--e.g. TextBox doesn't have any predefined text of its own as it can be changed at runtime by user, hence is identified by the label next to it.
+        /// Finds UIItem which matches specified type and identification.
+        /// In case of multiple items of this type the first one found would be returned,
+        /// which cannot be guaranteed to be the same across multiple invocations. 
+        /// For managed applications this is name given to controls in the application code.
+        /// For unmanaged applications this is text of the control or label next to it if it doesn't have well defined text.
+        /// <!--e.g. TextBox doesn't have any predefined text of its own as it can be changed at runtime by user, hence is identified by the label next to it.
         /// If there is no label then Get<T> or Get<T>(SearchCriteria) method can be used.-->
         /// </summary>
         /// <typeparam name="T">IUIItem implementation</typeparam>
         /// <param name="primaryIdentification">
-        ///     For managed application this is the name provided in application code and unmanaged application this is
-        ///     the text or label next to it based identification
+        /// For managed application this is the name provided in application code and unmanaged application this is
+        /// the text or label next to it based identification
         /// </param>
         /// <returns>First item of supplied type and identification</returns>
         /// <exception cref="AutomationException">when item not found</exception>
@@ -52,9 +52,9 @@ namespace TestStack.White.UIItems
         T Get<T>(string primaryIdentification) where T : IUIItem;
 
         /// <summary>
-        ///     Finds UIItem which matches specified type and searchCriteria. Type supplied need not be supplied again in
-        ///     SearchCondition.
-        ///     <!--e.g. in Get<Button>(SearchCriteria.ByAutomationId("OK").ByControlType(typeof(Button)).Indexed(1) the ByControlType(typeof(Button)) part 
+        /// Finds UIItem which matches specified type and searchCriteria. 
+        /// Type supplied need not be supplied again in SearchCondition.
+        /// <!--e.g. in Get<Button>(SearchCriteria.ByAutomationId("OK").ByControlType(typeof(Button)).Indexed(1) the ByControlType(typeof(Button)) part 
         /// is redundant. Look at documentation of SearchCriteria for details on it.-->
         /// </summary>
         /// <code>
@@ -67,8 +67,8 @@ namespace TestStack.White.UIItems
         T Get<T>(SearchCriteria searchCriteria) where T : IUIItem;
 
         /// <summary>
-        ///     Finds UIItem which matches specified searchCriteria using the default BusyTimeout. Look at documentation
-        ///     of SearchCriteria for details on it.
+        /// Finds UIItem which matches specified searchCriteria using the default BusyTimeout. 
+        /// Look at documentation of SearchCriteria for details on it.
         /// </summary>
         /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
         /// <returns>First items matching the criteria</returns>
@@ -77,8 +77,8 @@ namespace TestStack.White.UIItems
         IUIItem Get(SearchCriteria searchCriteria);
 
         /// <summary>
-        ///     Finds UIItem which matches specified type and searchCriteria. Look at documentation of SearchCriteria for details
-        ///     on it.
+        /// Finds UIItem which matches specified type and searchCriteria. 
+        /// Look at documentation of SearchCriteria for details on it.
         /// </summary>
         /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
         /// <param name="busyTimeout">Time to wait for item to come on-screen before returning off-screen element, if found.</param>
@@ -92,7 +92,7 @@ namespace TestStack.White.UIItems
         #region Get UI Items
 
         /// <summary>
-        ///     Finds all UIItems using the default BusyTimeout. 
+        /// Finds all UIItems using the default BusyTimeout. 
         /// </summary>
         /// <returns>Array of all <see cref="IUIItem"/> that can be found</returns>
         /// <exception cref="AutomationException">when item not found</exception>
@@ -100,8 +100,8 @@ namespace TestStack.White.UIItems
         IUIItem[] GetMultiple();
 
         /// <summary>
-        ///     Finds UIItems which matche a specified searchCriteria using the default BusyTimeout. 
-        ///     Look at documentation of SearchCriteria for details on it.
+        /// Finds UIItems which matche a specified searchCriteria using the default BusyTimeout. 
+        /// Look at documentation of SearchCriteria for details on it.
         /// </summary>
         /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
         /// <returns>Array of <see cref="IUIItem"/> matching the criteria</returns>
@@ -110,15 +110,15 @@ namespace TestStack.White.UIItems
         IUIItem[] GetMultiple(SearchCriteria searchCriteria);
 
         /// <summary>
-        ///     Finds all UIItems of Type T using the default BusyTimeout. 
+        /// Finds all UIItems of Type T using the default BusyTimeout. 
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <returns>An array of Items of T</returns>
         T[] GetMultiple<T>() where T : IUIItem;
 
         /// <summary>
-        ///     Finds all UIItems of type T and adhering to a specific Search Criteria using the default BusyTimeout. 
-        ///     Look at documentation of SearchCriteria for details on it.
+        /// Finds all UIItems of type T and adhering to a specific Search Criteria using the default BusyTimeout. 
+        /// Look at documentation of SearchCriteria for details on it.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
@@ -130,25 +130,25 @@ namespace TestStack.White.UIItems
         #region UI Item Exists
 
         /// <summary>
-        ///     Checks if an UIItem which matches specified type exists.
+        /// Checks if an UIItem which matches specified type exists.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         bool Exists<T>() where T : IUIItem;
 
         /// <summary>
-        ///     Checks if an UIItem which matches specified type exists.
+        /// Checks if an UIItem which matches specified type exists.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <param name="primaryIdentification">
-        ///     For managed application this is the name provided in application code and unmanaged application this is
-        ///     the text or label next to it based identification
+        /// For managed application this is the name provided in application code and unmanaged application this is
+        /// the text or label next to it based identification
         /// </param>
         /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         bool Exists<T>(string primaryIdentification) where T : IUIItem;
 
         /// <summary>
-        ///     Checks if an UIItem which matches specified type exists.
+        /// Checks if an UIItem which matches specified type exists.
         /// </summary>
         /// <typeparam name="T">IUIItem type e.g. Button, TextBox</typeparam>
         /// <param name="searchCriteria">Criteria provided to search UIItem</param>
@@ -156,7 +156,7 @@ namespace TestStack.White.UIItems
         bool Exists<T>(SearchCriteria searchCriteria) where T : IUIItem;
 
         /// <summary>
-        ///     Checks if an UIItem which matches specified search criteria exists.
+        /// Checks if an UIItem which matches specified search criteria exists.
         /// <param name="searchCriteria">Criteria provided to search UIItem</param>
         /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         bool Exists(SearchCriteria searchCriteria);

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -421,7 +421,7 @@ namespace TestStack.White.UIItems
             }
         }
 
-        internal virtual UIItemContainer AsContainer()
+        internal virtual IUIItemContainer AsContainer()
         {
             return new UIItemContainer(AutomationElement, ActionListener);
         }

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -444,8 +444,7 @@ namespace TestStack.White.UIItems
         /// </summary>
         public virtual void DrawHighlight(Color color)
         {
-            Rect rectangle = AutomationElement.Current.BoundingRectangle;
-
+            var rectangle = AutomationElement.Current.BoundingRectangle;
             if (rectangle != Rect.Empty)
             {
                 new Drawing.FrameRectangle(color, rectangle).Highlight();

--- a/src/TestStack.White/UIItems/UIItemContainer.cs
+++ b/src/TestStack.White/UIItems/UIItemContainer.cs
@@ -51,7 +51,7 @@ namespace TestStack.White.UIItems
         #endregion
         
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.ToolTip" />
+        /// Implements <see cref="IUIItemContainer.ToolTip" />
         /// </summary>
         public virtual ToolTip ToolTip
         {
@@ -59,7 +59,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.GetToolTipOn" />
+        /// Implements <see cref="IUIItemContainer.GetToolTipOn" />
         /// </summary>
         public virtual ToolTip GetToolTipOn(IUIItem uiItem)
         {
@@ -71,7 +71,7 @@ namespace TestStack.White.UIItems
         #region Get UI Item
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Get{T}()" />
+        /// Implements <see cref="IUIItemContainer.Get{T}()" />
         /// </summary>
         public virtual T Get<T>() where T : IUIItem
         {
@@ -79,7 +79,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Get{T}(string)" />
+        /// Implements <see cref="IUIItemContainer.Get{T}(string)" />
         /// </summary>
         public virtual T Get<T>(string primaryIdentification) where T : IUIItem
         {
@@ -87,7 +87,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Get{T}(SearchCriteria)" />
+        /// Implements <see cref="IUIItemContainer.Get{T}(SearchCriteria)" />
         /// </summary>
         public virtual T Get<T>(SearchCriteria searchCriteria) where T : IUIItem
         {
@@ -95,7 +95,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Get(SearchCriteria)" />
+        /// Implements <see cref="IUIItemContainer.Get(SearchCriteria)" />
         /// </summary>
         public virtual IUIItem Get(SearchCriteria searchCriteria)
         {
@@ -103,13 +103,13 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Get(SearchCriteria, TimeSpan)" />
+        /// Implements <see cref="IUIItemContainer.Get(SearchCriteria, TimeSpan)" />
         /// </summary>
         public virtual IUIItem Get(SearchCriteria searchCriteria, TimeSpan busyTimeout)
         {
             try
             {
-                IUIItem uiItem = Retry.For(() =>
+                var uiItem = Retry.For(() =>
                     CurrentContainerItemFactory.Find(searchCriteria, WindowSession),
                     b =>
                         (bool) b.AutomationElement.GetCurrentPropertyValue(AutomationElement.IsOffscreenProperty, false),
@@ -117,7 +117,7 @@ namespace TestStack.White.UIItems
 
                 if (uiItem == null)
                 {
-                    string debugDetails = Debug.Details(automationElement);
+                    var debugDetails = Debug.Details(automationElement);
                     throw new AutomationException(string.Format("Failed to get {0}", searchCriteria), debugDetails);
                 }
 
@@ -131,7 +131,7 @@ namespace TestStack.White.UIItems
             }
             catch (Exception e)
             {
-                string debugDetails = Debug.Details(automationElement);
+                var debugDetails = Debug.Details(automationElement);
                 throw new WhiteException(string.Format("Error occured while geting {0}", searchCriteria), debugDetails,
                     e);
             }
@@ -142,15 +142,15 @@ namespace TestStack.White.UIItems
         #region Get UI Items
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.GetMultiple()" />
+        /// Implements <see cref="IUIItemContainer.GetMultiple()" />
         /// </summary>
-        public IUIItem[] GetMultiple()
+        public virtual IUIItem[] GetMultiple()
         {
             return GetMultiple(SearchCriteria.All);
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.GetMultiple(SearchCriteria)" />
+        /// Implements <see cref="IUIItemContainer.GetMultiple(SearchCriteria)" />
         /// </summary>
         public virtual IUIItem[] GetMultiple(SearchCriteria criteria)
         {
@@ -158,17 +158,17 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.GetMultiple{T}()" />
+        /// Implements <see cref="IUIItemContainer.GetMultiple{T}()" />
         /// </summary>
-        public T[] GetMultiple<T>() where T : IUIItem
+        public virtual T[] GetMultiple<T>() where T : IUIItem
         {
             return GetMultiple<T>(SearchCriteria.All);
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.GetMultiple{T}(SearchCriteria)" />
+        /// Implements <see cref="IUIItemContainer.GetMultiple{T}(SearchCriteria)" />
         /// </summary>
-        public T[] GetMultiple<T>(SearchCriteria searchCriteria) where T : IUIItem
+        public virtual T[] GetMultiple<T>(SearchCriteria searchCriteria) where T : IUIItem
         {
             var items = GetMultiple(searchCriteria.AndControlType(typeof(T), Framework));
             return items.Select(item => (T)item).Where(cast => cast != null).ToArray();
@@ -179,7 +179,7 @@ namespace TestStack.White.UIItems
         #region UI Item Exists
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Exists{T}()" />
+        /// Implements <see cref="IUIItemContainer.Exists{T}()" />
         /// </summary>
         public virtual bool Exists<T>() where T : IUIItem
         {
@@ -187,7 +187,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Exists{T}(string)" />
+        /// Implements <see cref="IUIItemContainer.Exists{T}(string)" />
         /// </summary>
         public virtual bool Exists<T>(string primaryIdentification) where T : IUIItem
         {
@@ -195,7 +195,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Exists{T}(SearchCriteria)" />
+        /// Implements <see cref="IUIItemContainer.Exists{T}(SearchCriteria)" />
         /// </summary>
         public virtual bool Exists<T>(SearchCriteria searchCriteria) where T : IUIItem
         {
@@ -203,7 +203,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Implements <see cref="IUIItemContainer.Exists{SearchCriteria}()" />
+        /// Implements <see cref="IUIItemContainer.Exists{SearchCriteria}()" />
         /// </summary>
         public virtual bool Exists(SearchCriteria searchCriteria)
         {
@@ -223,9 +223,9 @@ namespace TestStack.White.UIItems
         #region Public
 
         /// <summary>
-        ///     Returns a list of UIItems contained in the container/window. This is not the same as AutomationElements because
-        ///     white needs to translate
-        ///     AutomationElements to UIItem. Hence for certain AE there might not be corresponding UIItem type.
+        /// Returns a list of UIItems contained in the container/window. 
+        /// This is not the same as AutomationElements because white needs to translate AutomationElements to UIItem. 
+        /// Hence for certain AE there might not be corresponding UIItem type.
         /// </summary>
         public virtual UIItemCollection Items
         {
@@ -233,9 +233,9 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Returns a keyboard which is associated to this window. Any operation performed using the mouse would wait till the
-        ///     window is busy after this
-        ///     operation. Before any operation is performed the window is brought to focus.
+        /// Returns a keyboard which is associated to this window. 
+        /// Any operation performed using the mouse would wait till the window is busy after this operation. 
+        /// Before any operation is performed the window is brought to focus.
         /// </summary>
         public virtual AttachedKeyboard Keyboard
         {
@@ -243,9 +243,9 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Returns a mouse which is associated to this window. Any operation performed using the mouse would wait till the
-        ///     window is busy after this
-        ///     operation. Before any operation is performed the window is brought to focus.
+        /// Returns a mouse which is associated to this window. 
+        /// Any operation performed using the mouse would wait till the window is busy after this operation. 
+        /// Before any operation is performed the window is brought to focus.
         /// </summary>
         public virtual AttachedMouse Mouse
         {
@@ -276,6 +276,10 @@ namespace TestStack.White.UIItems
             get { return CurrentContainerItemFactory.FindAll<Tab>(); }
         }
 
+        /// <summary>
+        /// Overrides <see cref="UIItem.ActionPerforming"/>
+        /// </summary>
+        /// <param name="uiItem"></param>
         public override void ActionPerforming(UIItem uiItem)
         {
             Focus();
@@ -283,14 +287,18 @@ namespace TestStack.White.UIItems
             screenItem.MakeVisible(this);
         }
 
+        /// <summary>
+        /// Implements <see cref="IVerticalSpanProvider.VerticalSpan"/>
+        /// </summary>
         public virtual VerticalSpan VerticalSpan
         {
             get { return new VerticalSpan(Bounds); }
         }
 
         /// <summary>
-        ///     Applicable only if CacheMode is used. This is for internal purpose of white and should not be used, as caching by
-        ///     itself is not supported
+        /// Applicable only if CacheMode is used. 
+        /// This is for internal purpose of white and should not be used, 
+        /// as caching by itself is not supported
         /// </summary>
         /// <param name="option"></param>
         public virtual void ReInitialize(InitializeOption option)
@@ -312,13 +320,13 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        ///     Find all the UIItems which belongs to a window and are within (bounds of) another UIItem.
+        /// Find all the UIItems which belongs to a window and are within (bounds of) another UIItem.
         /// </summary>
         /// <param name="containingItem">Containing item</param>
         /// <returns>List of all the items.</returns>
         public virtual List<UIItem> ItemsWithin(UIItem containingItem)
         {
-            UIItemCollection itemsWithin = factory.ItemsWithin(containingItem.Bounds, this);
+            var itemsWithin = factory.ItemsWithin(containingItem.Bounds, this);
             return itemsWithin.Where(item => !item.Equals(containingItem)).Cast<UIItem>().ToList();
         }
 
@@ -337,7 +345,7 @@ namespace TestStack.White.UIItems
         {
             var customUIItem = uiItem as CustomUIItem;
             if (customUIItem == null) return;
-            FieldInfo interceptorField = customUIItem.GetType().GetField("__interceptors",
+            var interceptorField = customUIItem.GetType().GetField("__interceptors",
                 BindingFlags.NonPublic | BindingFlags.Public |
                 BindingFlags.Instance);
             var interceptors = (IInterceptor[]) interceptorField.GetValue(customUIItem);

--- a/src/TestStack.White/UIItems/UIItemContainer.cs
+++ b/src/TestStack.White/UIItems/UIItemContainer.cs
@@ -28,16 +28,19 @@ namespace TestStack.White.UIItems
         protected readonly CurrentContainerItemFactory CurrentContainerItemFactory;
         protected WindowSession WindowSession = new NullWindowSession();
 
+        #region Constructor
+
         protected UIItemContainer()
         {
         }
 
         public UIItemContainer(AutomationElement automationElement, IActionListener actionListener,
-                               InitializeOption initializeOption,
-                               WindowSession windowSession) : base(automationElement, actionListener)
+            InitializeOption initializeOption,
+            WindowSession windowSession) : base(automationElement, actionListener)
         {
             WindowSession = windowSession;
-            CurrentContainerItemFactory = new CurrentContainerItemFactory(factory, initializeOption, automationElement, ChildrenActionListener);
+            CurrentContainerItemFactory = new CurrentContainerItemFactory(factory, initializeOption, automationElement,
+                ChildrenActionListener);
         }
 
         public UIItemContainer(AutomationElement automationElement, IActionListener actionListener)
@@ -45,75 +48,76 @@ namespace TestStack.White.UIItems
         {
         }
 
+        #endregion
+        
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.ToolTip" />
+        /// </summary>
+        public virtual ToolTip ToolTip
+        {
+            get { return factory.ToolTip; }
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.GetToolTipOn" />
+        /// </summary>
+        public virtual ToolTip GetToolTipOn(IUIItem uiItem)
+        {
+            Mouse.Location = uiItem.Bounds.Center();
+            uiItem.Focus();
+            return ToolTip;
+        }
+
+        #region Get UI Item
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Get{T}()" />
+        /// </summary>
         public virtual T Get<T>() where T : IUIItem
         {
             return Get<T>(SearchCriteria.All);
         }
 
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Get{T}(string)" />
+        /// </summary>
         public virtual T Get<T>(string primaryIdentification) where T : IUIItem
         {
             return Get<T>(SearchCriteria.ByAutomationId(primaryIdentification));
         }
 
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Get{T}(SearchCriteria)" />
+        /// </summary>
         public virtual T Get<T>(SearchCriteria searchCriteria) where T : IUIItem
         {
             return (T) Get(searchCriteria.AndControlType(typeof (T), Framework));
         }
 
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Get(SearchCriteria)" />
+        /// </summary>
         public virtual IUIItem Get(SearchCriteria searchCriteria)
         {
             return Get(searchCriteria, CoreAppXmlConfiguration.Instance.BusyTimeout());
         }
 
-        public virtual bool Exists<T>() where T : IUIItem
-        {
-            return Exists<T>(SearchCriteria.All);
-        }
-
-        public virtual bool Exists<T>(string primaryIdentification) where T : IUIItem
-        {
-            return Exists<T>(SearchCriteria.ByAutomationId(primaryIdentification));
-        }
-
-        public virtual bool Exists<T>(SearchCriteria searchCriteria) where T : IUIItem
-        {
-            return Exists(searchCriteria.AndControlType(typeof(T), Framework));
-        }
-
-        public virtual bool Exists(SearchCriteria searchCriteria)
-        {
-            try
-            {
-                Get(searchCriteria, TimeSpan.FromMilliseconds(0));
-                return true;
-            }
-            catch (AutomationException)
-            {
-                return false;
-            }
-
-        }
-
         /// <summary>
-        /// Finds UIItem which matches specified type and searchCriteria. Look at documentation of SearchCriteria for details on it.
+        ///     Implements <see cref="IUIItemContainer.Get(SearchCriteria, TimeSpan)" />
         /// </summary>
-        /// <param name="searchCriteria">Criteria provided to search IUIItem</param>
-        /// <param name="timeout">Time to wait for item to come on-screen before returning off-screen element, if found.</param>
-        /// <returns>First items matching the criteria</returns>
-        /// <exception cref="AutomationException">when item not found</exception>
-        /// <exception cref="WhiteException">when any errors occured during search</exception>
-        public virtual IUIItem Get(SearchCriteria searchCriteria, TimeSpan timeout)
+        public virtual IUIItem Get(SearchCriteria searchCriteria, TimeSpan busyTimeout)
         {
             try
             {
-                var uiItem = Retry.For(() =>
+                IUIItem uiItem = Retry.For(() =>
                     CurrentContainerItemFactory.Find(searchCriteria, WindowSession),
-                    b =>(bool)b.AutomationElement.GetCurrentPropertyValue(AutomationElement.IsOffscreenProperty, false),
-                    timeout);
+                    b =>
+                        (bool) b.AutomationElement.GetCurrentPropertyValue(AutomationElement.IsOffscreenProperty, false),
+                    busyTimeout);
 
                 if (uiItem == null)
                 {
-                    var debugDetails = Debug.Details(automationElement);
+                    string debugDetails = Debug.Details(automationElement);
                     throw new AutomationException(string.Format("Failed to get {0}", searchCriteria), debugDetails);
                 }
 
@@ -127,55 +131,101 @@ namespace TestStack.White.UIItems
             }
             catch (Exception e)
             {
-                var debugDetails = Debug.Details(automationElement);
-
-                throw new WhiteException(string.Format("Error occured while geting {0}", searchCriteria), debugDetails, e);
+                string debugDetails = Debug.Details(automationElement);
+                throw new WhiteException(string.Format("Error occured while geting {0}", searchCriteria), debugDetails,
+                    e);
             }
         }
 
-        private void HandleIfUIItemContainer(IUIItem uiItem)
-        {
-            var uiItemContainer = uiItem as UIItemContainer;
-            if (uiItemContainer == null) return;
-            uiItemContainer.Associate(WindowSession);
-        }
+        #endregion
 
-        private void HandleIfCustomUIItem(IUIItem uiItem)
-        {
-            var customUIItem = uiItem as CustomUIItem;
-            if (customUIItem == null) return;
-            FieldInfo interceptorField = customUIItem.GetType().GetField("__interceptors",
-                                                                         BindingFlags.NonPublic | BindingFlags.Public |
-                                                                         BindingFlags.Instance);
-            var interceptors = (IInterceptor[]) interceptorField.GetValue(customUIItem);
-            var realCustomUIItem = (CustomUIItem) ((CoreInterceptor) interceptors[0]).Context.UiItem;
-            realCustomUIItem.SetContainer(new UIItemContainer(customUIItem.AutomationElement, ChildrenActionListener,
-                                                              InitializeOption.NoCache, WindowSession));
-        }
+        #region Get UI Items
 
         /// <summary>
-        /// Applicable only if CacheMode is used. This is for internal purpose of white and should not be used, as caching by itself is not supported
+        ///     Implements <see cref="IUIItemContainer.GetMultiple()" />
         /// </summary>
-        /// <param name="option"></param>
-        public virtual void ReInitialize(InitializeOption option)
+        public IUIItem[] GetMultiple()
         {
-            CurrentContainerItemFactory.ReInitialize(option);
+            return GetMultiple(SearchCriteria.All);
         }
 
-        protected virtual IActionListener ChildrenActionListener
-        {
-            get { return HasActionInterceptionBehaviour() ? this : actionListener; }
-        }
-
-        private bool HasActionInterceptionBehaviour()
-        {
-            return ScrollBars.CanScroll;
-        }
-
-        //BUG: Try this method out with all windows on the desktop and see if it works
         /// <summary>
-        /// Returns a list of UIItems contained in the container/window. This is not the same as AutomationElements because white needs to translate
-        /// AutomationElements to UIItem. Hence for certain AE there might not be corresponding UIItem type.
+        ///     Implements <see cref="IUIItemContainer.GetMultiple(SearchCriteria)" />
+        /// </summary>
+        public virtual IUIItem[] GetMultiple(SearchCriteria criteria)
+        {
+            return CurrentContainerItemFactory.FindAll(criteria).ToArray();
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.GetMultiple{T}()" />
+        /// </summary>
+        public T[] GetMultiple<T>() where T : IUIItem
+        {
+            return GetMultiple<T>(SearchCriteria.All);
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.GetMultiple{T}(SearchCriteria)" />
+        /// </summary>
+        public T[] GetMultiple<T>(SearchCriteria searchCriteria) where T : IUIItem
+        {
+            var items = GetMultiple(searchCriteria.AndControlType(typeof(T), Framework));
+            return items.Select(item => (T)item).Where(cast => cast != null).ToArray();
+        }
+
+        #endregion
+
+        #region UI Item Exists
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Exists{T}()" />
+        /// </summary>
+        public virtual bool Exists<T>() where T : IUIItem
+        {
+            return Exists<T>(SearchCriteria.All);
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Exists{T}(string)" />
+        /// </summary>
+        public virtual bool Exists<T>(string primaryIdentification) where T : IUIItem
+        {
+            return Exists<T>(SearchCriteria.ByAutomationId(primaryIdentification));
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Exists{T}(SearchCriteria)" />
+        /// </summary>
+        public virtual bool Exists<T>(SearchCriteria searchCriteria) where T : IUIItem
+        {
+            return Exists(searchCriteria.AndControlType(typeof(T), Framework));
+        }
+
+        /// <summary>
+        ///     Implements <see cref="IUIItemContainer.Exists{SearchCriteria}()" />
+        /// </summary>
+        public virtual bool Exists(SearchCriteria searchCriteria)
+        {
+            try
+            {
+                Get(searchCriteria, TimeSpan.FromMilliseconds(0));
+                return true;
+            }
+            catch (AutomationException)
+            {
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region Public
+
+        /// <summary>
+        ///     Returns a list of UIItems contained in the container/window. This is not the same as AutomationElements because
+        ///     white needs to translate
+        ///     AutomationElements to UIItem. Hence for certain AE there might not be corresponding UIItem type.
         /// </summary>
         public virtual UIItemCollection Items
         {
@@ -183,8 +233,9 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        /// Returns a keyboard which is associated to this window. Any operation performed using the mouse would wait till the window is busy after this
-        /// operation. Before any operation is performed the window is brought to focus.
+        ///     Returns a keyboard which is associated to this window. Any operation performed using the mouse would wait till the
+        ///     window is busy after this
+        ///     operation. Before any operation is performed the window is brought to focus.
         /// </summary>
         public virtual AttachedKeyboard Keyboard
         {
@@ -192,34 +243,13 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        /// Returns a mouse which is associated to this window. Any operation performed using the mouse would wait till the window is busy after this
-        /// operation. Before any operation is performed the window is brought to focus.
+        ///     Returns a mouse which is associated to this window. Any operation performed using the mouse would wait till the
+        ///     window is busy after this
+        ///     operation. Before any operation is performed the window is brought to focus.
         /// </summary>
         public virtual AttachedMouse Mouse
         {
             get { return new AttachedMouse(mouse, this); }
-        }
-
-        public virtual IUIItem[] GetMultiple(SearchCriteria criteria)
-        {
-            return CurrentContainerItemFactory.FindAll(criteria).ToArray();
-        }
-
-        internal virtual void Associate(WindowSession session)
-        {
-            WindowSession = session;
-        }
-
-        public virtual VerticalSpan VerticalSpan
-        {
-            get { return new VerticalSpan(Bounds); }
-        }
-
-        public override void ActionPerforming(UIItem uiItem)
-        {
-            Focus();
-            var screenItem = new ScreenItem(uiItem, ScrollBars);
-            screenItem.MakeVisible(this);
         }
 
         public virtual MenuBar MenuBar
@@ -227,26 +257,9 @@ namespace TestStack.White.UIItems
             get { return (MenuBar) Get(SearchCriteria.ForMenuBar(Framework)); }
         }
 
-        public virtual MenuBar GetMenuBar(SearchCriteria searchCriteria)
-        {
-            return (MenuBar) Get(SearchCriteria.ForMenuBar(Framework).Merge(searchCriteria));
-        }
-
         public virtual List<MenuBar> MenuBars
         {
             get { return new List<MenuBar>(GetMultiple(SearchCriteria.ForMenuBar(Framework)).OfType<MenuBar>()); }
-        }
-
-        public virtual ToolTip ToolTip
-        {
-            get { return factory.ToolTip; }
-        }
-
-        public virtual ToolTip GetToolTipOn(UIItem uiItem)
-        {
-            Mouse.Location = uiItem.Bounds.Center();
-            uiItem.Focus(); 
-            return ToolTip;
         }
 
         public virtual ToolStrip ToolStrip
@@ -263,6 +276,33 @@ namespace TestStack.White.UIItems
             get { return CurrentContainerItemFactory.FindAll<Tab>(); }
         }
 
+        public override void ActionPerforming(UIItem uiItem)
+        {
+            Focus();
+            var screenItem = new ScreenItem(uiItem, ScrollBars);
+            screenItem.MakeVisible(this);
+        }
+
+        public virtual VerticalSpan VerticalSpan
+        {
+            get { return new VerticalSpan(Bounds); }
+        }
+
+        /// <summary>
+        ///     Applicable only if CacheMode is used. This is for internal purpose of white and should not be used, as caching by
+        ///     itself is not supported
+        /// </summary>
+        /// <param name="option"></param>
+        public virtual void ReInitialize(InitializeOption option)
+        {
+            CurrentContainerItemFactory.ReInitialize(option);
+        }
+
+        public virtual MenuBar GetMenuBar(SearchCriteria searchCriteria)
+        {
+            return (MenuBar) Get(SearchCriteria.ForMenuBar(Framework).Merge(searchCriteria));
+        }
+
         public virtual ToolStrip GetToolStrip(string primaryIdentification)
         {
             var toolStrip = (ToolStrip) Get(SearchCriteria.ByAutomationId(primaryIdentification));
@@ -272,7 +312,7 @@ namespace TestStack.White.UIItems
         }
 
         /// <summary>
-        /// Find all the UIItems which belongs to a window and are within (bounds of) another UIItem.
+        ///     Find all the UIItems which belongs to a window and are within (bounds of) another UIItem.
         /// </summary>
         /// <param name="containingItem">Containing item</param>
         /// <returns>List of all the items.</returns>
@@ -282,6 +322,44 @@ namespace TestStack.White.UIItems
             return itemsWithin.Where(item => !item.Equals(containingItem)).Cast<UIItem>().ToList();
         }
 
+        #endregion
+
+        #region Private
+
+        private void HandleIfUIItemContainer(IUIItem uiItem)
+        {
+            var uiItemContainer = uiItem as UIItemContainer;
+            if (uiItemContainer == null) return;
+            uiItemContainer.Associate(WindowSession);
+        }
+
+        private void HandleIfCustomUIItem(IUIItem uiItem)
+        {
+            var customUIItem = uiItem as CustomUIItem;
+            if (customUIItem == null) return;
+            FieldInfo interceptorField = customUIItem.GetType().GetField("__interceptors",
+                BindingFlags.NonPublic | BindingFlags.Public |
+                BindingFlags.Instance);
+            var interceptors = (IInterceptor[]) interceptorField.GetValue(customUIItem);
+            var realCustomUIItem = (CustomUIItem) ((CoreInterceptor) interceptors[0]).Context.UiItem;
+            realCustomUIItem.SetContainer(new UIItemContainer(customUIItem.AutomationElement, ChildrenActionListener,
+                InitializeOption.NoCache, WindowSession));
+        }
+
+        private bool HasActionInterceptionBehaviour()
+        {
+            return ScrollBars.CanScroll;
+        }
+
+        #endregion
+
+        #region Protected
+
+        protected virtual IActionListener ChildrenActionListener
+        {
+            get { return HasActionInterceptionBehaviour() ? this : actionListener; }
+        }
+
         protected virtual void CustomWait()
         {
             if (CoreAppXmlConfiguration.Instance.AdditionalWaitHook != null)
@@ -289,5 +367,17 @@ namespace TestStack.White.UIItems
                 CoreAppXmlConfiguration.Instance.AdditionalWaitHook.WaitFor(this);
             }
         }
+
+        #endregion
+
+        #region Internal
+
+        //BUG: Try this method out with all windows on the desktop and see if it works
+        internal virtual void Associate(WindowSession session)
+        {
+            WindowSession = session;
+        }
+
+        #endregion
     }
 }

--- a/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
+++ b/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
@@ -14,7 +14,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         #region Get Single UI Item
 
         /// <summary>
-        ///     Get a single UI Item by a specific Search Criteria
+        /// Get a single UI Item by a specific Search Criteria
         /// </summary>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
         /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
@@ -25,7 +25,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Get the first item of a certain type
+        /// Get the first item of a certain type
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -36,7 +36,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Get the first item of a certain type and a specific Search Criteria
+        /// Get the first item of a certain type and a specific Search Criteria
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -52,7 +52,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         #region Get Multiple UI Items
 
         /// <summary>
-        ///     Get multiple UI Items
+        /// Get multiple UI Items
         /// </summary>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
         /// <returns>Located UI Items</returns>
@@ -75,7 +75,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Get multiple UI Items
+        /// Get multiple UI Items
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -86,7 +86,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Get multiple UI Items
+        /// Get multiple UI Items
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -104,7 +104,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         #region Exists
 
         /// <summary>
-        ///     Check if any UI Item of a certain Type exists
+        /// Check if any UI Item of a certain Type exists
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -115,7 +115,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Check if any UI Item of a certain Type exists
+        /// Check if any UI Item of a certain Type exists
         /// </summary>
         /// <typeparam name="T">Type of Item</typeparam>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
@@ -127,7 +127,7 @@ namespace TestStack.White.UIItems.WPFUIItems
         }
 
         /// <summary>
-        ///     Check if any UI Item of a certain Type exists
+        /// Check if any UI Item of a certain Type exists
         /// </summary>
         /// <param name="uiItem">The root UI Item from were to start searching</param>
         /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
@@ -141,7 +141,7 @@ namespace TestStack.White.UIItems.WPFUIItems
 
         #region Private
 
-        static IUIItemContainer GetUiItemContainer(IUIItem uiItem)
+        private static IUIItemContainer GetUiItemContainer(IUIItem uiItem)
         {
             if (!(uiItem is UIItem))
             {

--- a/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
+++ b/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
@@ -4,63 +4,156 @@ using TestStack.White.UIItems.Finders;
 
 namespace TestStack.White.UIItems.WPFUIItems
 {
+    /// <summary>
+    ///     Extention Methods for <see cref="IUIItem" /> available only for <see cref="WindowsFramework.Wpf" /> Framework
+    /// </summary>
     public static class WPFUIItem
     {
-        private static readonly ILogger Logger = CoreAppXmlConfiguration.Instance.LoggerFactory.Create(typeof(WPFUIItem));
+        static readonly ILogger Logger = CoreAppXmlConfiguration.Instance.LoggerFactory.Create(typeof (WPFUIItem));
 
-        public static T Get<T>(this IUIItem uiItem, SearchCriteria searchCriteria) where T : UIItem
-        {
-            var uiItemContainer = GetUiItemContainer(uiItem);
-            return uiItemContainer.Get<T>(searchCriteria);
-        }
+        #region Get Single UI Item
 
-        public static T Get<T>(this IUIItem uiItem, string primaryIdentification) where T : UIItem
-        {
-            var uiItemContainer = GetUiItemContainer(uiItem);
-            return uiItemContainer.Get<T>(primaryIdentification);
-        }
-
+        /// <summary>
+        ///     Get a single UI Item by a specific Search Criteria
+        /// </summary>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns>Located UI Item</returns>
         public static IUIItem Get(this IUIItem uiItem, SearchCriteria searchCriteria)
         {
             return GetUiItemContainer(uiItem).Get(searchCriteria);
         }
 
-        public static IUIItem Get(this IUIItem uiItem, string primaryIdentification)
+        /// <summary>
+        ///     Get the first item of a certain type
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <returns>Located UI Item</returns>
+        public static T Get<T>(this IUIItem uiItem) where T : IUIItem
         {
-            return GetUiItemContainer(uiItem).Get(primaryIdentification);
+            return GetUiItemContainer(uiItem).Get<T>();
         }
 
-        public static IUIItem[] GetMultiple(this IUIItem uiItem, SearchCriteria criteria)
+        /// <summary>
+        ///     Get the first item of a certain type and a specific Search Criteria
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns>Located UI Item</returns>
+        public static T Get<T>(this IUIItem uiItem, SearchCriteria searchCriteria) where T : IUIItem
         {
-            return GetUiItemContainer(uiItem).GetMultiple(criteria);
+            return searchCriteria == null ? uiItem.Get<T>() : GetUiItemContainer(uiItem).Get<T>(searchCriteria);
         }
 
+        #endregion
+
+        #region Get Multiple UI Items
+
+        /// <summary>
+        ///     Get multiple UI Items
+        /// </summary>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <returns>Located UI Items</returns>
+        public static IUIItem[] GetMultiple(this IUIItem uiItem)
+        {
+            return GetUiItemContainer(uiItem).GetMultiple();
+        }
+
+        /// <summary>
+        ///     Get multiple UI Items by a specific Search Critera
+        /// </summary>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns>Located UI Items</returns>
+        public static IUIItem[] GetMultiple(this IUIItem uiItem, SearchCriteria searchCriteria)
+        {
+            return searchCriteria == null
+                ? uiItem.GetMultiple()
+                : GetUiItemContainer(uiItem).GetMultiple(searchCriteria);
+        }
+
+        /// <summary>
+        ///     Get multiple UI Items
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <returns>Located UI Items</returns>
+        public static T[] GetMultiple<T>(this IUIItem uiItem) where T : IUIItem
+        {
+            return GetUiItemContainer(uiItem).GetMultiple<T>();
+        }
+
+        /// <summary>
+        ///     Get multiple UI Items
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns>Located UI Items</returns>
+        public static T[] GetMultiple<T>(this IUIItem uiItem, SearchCriteria searchCriteria) where T : IUIItem
+        {
+            return searchCriteria == null
+                ? uiItem.GetMultiple<T>()
+                : GetUiItemContainer(uiItem).GetMultiple<T>(searchCriteria);
+        }
+
+        #endregion
+
+        #region Exists
+
+        /// <summary>
+        ///     Check if any UI Item of a certain Type exists
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         public static bool Exists<T>(this IUIItem uiItem) where T : IUIItem
         {
             return GetUiItemContainer(uiItem).Exists<T>(SearchCriteria.All);
         }
 
-        public static bool Exists<T>(this IUIItem uiItem, string primaryIdentification) where T : IUIItem
-        {
-            return GetUiItemContainer(uiItem).Exists<T>(SearchCriteria.ByAutomationId(primaryIdentification));
-        }
-
+        /// <summary>
+        ///     Check if any UI Item of a certain Type exists
+        /// </summary>
+        /// <typeparam name="T">Type of Item</typeparam>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         public static bool Exists<T>(this IUIItem uiItem, SearchCriteria searchCriteria) where T : IUIItem
         {
-            return GetUiItemContainer(uiItem).Exists(searchCriteria.AndControlType(typeof(T), uiItem.Framework));
+            return GetUiItemContainer(uiItem).Exists(searchCriteria.AndControlType(typeof (T), uiItem.Framework));
         }
 
+        /// <summary>
+        ///     Check if any UI Item of a certain Type exists
+        /// </summary>
+        /// <param name="uiItem">The root UI Item from were to start searching</param>
+        /// <param name="searchCriteria">The Search Criteria to use for the Search</param>
+        /// <returns><c>true</c> if there is any; otherwise, <c>false</c>.</returns>
         public static bool Exists(this IUIItem uiItem, SearchCriteria searchCriteria)
         {
             return GetUiItemContainer(uiItem).Exists(searchCriteria);
         }
 
-        private static UIItemContainer GetUiItemContainer(IUIItem uiItem)
+        #endregion
+
+        #region Private
+
+        static IUIItemContainer GetUiItemContainer(IUIItem uiItem)
         {
             if (!(uiItem is UIItem))
+            {
                 throw new WhiteException("Cannot get UI Item container, uiItem must be an instance of UIItem");
-            if (uiItem.Framework != WindowsFramework.Wpf) Logger.Warn("Only WPF items should be treated as container items");
-            return ((UIItem)uiItem).AsContainer();
+            }
+            if (uiItem.Framework != WindowsFramework.Wpf)
+            {
+                Logger.Warn("Only WPF items should be treated as container items");
+            }
+            return ((UIItem) uiItem).AsContainer();
         }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Extending and Documenting the Extention Methods for IUIItem in the WPFUIItem class.

Extended the IUIItemContainer Interface:
- Added Exists Methods
- Added further GetMultiple Methods
- Added Documentation

Extended the UIItemContainer Class
- Implementing the new methods defined in the Interface
- Code Documentaton
- Put in some Regions to declutter the Code abit

Extended the WPFUIItem Extention Methods Class
- Added Regions
- Added Documentation
- Changed the where Constraint from UIItem to IUIItem
- Added some more GetMultiple Methods