### PR TITLE
Small change to AsContainer

### DIFF
--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -201,10 +201,10 @@ namespace TestStack.White.UIItems
         /// <returns></returns>
         public virtual string ErrorProviderMessage(Window window)
         {
-            AutomationElement element =
+            var element =
                 AutomationElement.FromPoint(automationElement.Current.BoundingRectangle.ImmediateExteriorEast());
             if (element == null) return null;
-            Rect errorProviderBounds = element.Current.BoundingRectangle;
+            var errorProviderBounds = element.Current.BoundingRectangle;
             if (automationElement.Current.BoundingRectangle.Right != errorProviderBounds.Left) return null;
             mouse.Location = errorProviderBounds.Center();
             actionListener.ActionPerformed(Action.WindowMessage);
@@ -421,8 +421,16 @@ namespace TestStack.White.UIItems
             }
         }
 
-        internal virtual IUIItemContainer AsContainer()
+        /// <summary>
+        /// Make an <see cref="IUIItemContainer"/> out of the <see cref="IUIItem"/>
+        /// </summary>
+        /// <returns>Returns an <c><see cref="IUIItemContainer"/></c> if possibe</returns>
+        public virtual IUIItemContainer AsContainer()
         {
+            if (Framework != WindowsFramework.Wpf)
+            {
+                Logger.Warn("Only WPF items should be treated as container items");
+            }
             return new UIItemContainer(AutomationElement, ActionListener);
         }
 

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -430,6 +430,9 @@ namespace TestStack.White.UIItems
             if (Framework != WindowsFramework.Wpf)
             {
                 Logger.Warn("Only WPF items should be treated as container items");
+                throw new WhiteException(string.Format(
+                        "Cannot create a Container since the UI Item is not of the correct Framework Type {0}",
+                        WindowsFramework.Wpf));
             }
             return new UIItemContainer(AutomationElement, ActionListener);
         }

--- a/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
+++ b/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
@@ -1,5 +1,3 @@
-using Castle.Core.Logging;
-using TestStack.White.Configuration;
 using TestStack.White.UIItems.Finders;
 
 namespace TestStack.White.UIItems.WPFUIItems
@@ -9,8 +7,6 @@ namespace TestStack.White.UIItems.WPFUIItems
     /// </summary>
     public static class WPFUIItem
     {
-        static readonly ILogger Logger = CoreAppXmlConfiguration.Instance.LoggerFactory.Create(typeof (WPFUIItem));
-
         #region Get Single UI Item
 
         /// <summary>
@@ -143,15 +139,12 @@ namespace TestStack.White.UIItems.WPFUIItems
 
         private static IUIItemContainer GetUiItemContainer(IUIItem uiItem)
         {
-            if (!(uiItem is UIItem))
+            var item = uiItem as UIItem;
+            if (item == null)
             {
                 throw new WhiteException("Cannot get UI Item container, uiItem must be an instance of UIItem");
             }
-            if (uiItem.Framework != WindowsFramework.Wpf)
-            {
-                Logger.Warn("Only WPF items should be treated as container items");
-            }
-            return ((UIItem) uiItem).AsContainer();
+            return item.AsContainer();
         }
 
         #endregion


### PR DESCRIPTION
Small change to AsContainer.
Avoid double checking with "is" and then "as".
Do a Cast and then check on null.
The Check for WindowsFramework.Wpf is moved to UIItem.cs