### PR TITLE
Cleaning Up UIItem

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,6 +23,10 @@ None so far
   - TableVerticalScrollOffset to ITableVerticalScrollOffset
   - TreeNodeVisitor to ITreeNodeVisitor
   - MenuContainer to IMenuContainer
+  - UIItemEventListener to IUIItemEventListener
+- Renaming Functions
+  - Changes in IUIItem / UIItem
+    - Renamed the RaiseClickEvent to Invoke
 
 # 0.13.0 (7 June 2014)
 

--- a/src/TestStack.White.UITests/ControlTests/ButtonTests.cs
+++ b/src/TestStack.White.UITests/ControlTests/ButtonTests.cs
@@ -35,10 +35,10 @@ namespace TestStack.White.UITests.ControlTests
         }
 
         [Test]
-        public void RaiseClickEvent()
+        public void TestInvokePattern()
         {
             var button = MainWindow.Get<Button>("ButtonWithTooltip");
-            button.RaiseClickEvent();
+            button.Invoke();
             Assert.That(button.Text, Is.EqualTo("Clicked"));
         }
     }

--- a/src/TestStack.White/Recording/SafeAutomationEventHandler.cs
+++ b/src/TestStack.White/Recording/SafeAutomationEventHandler.cs
@@ -11,12 +11,12 @@ namespace TestStack.White.Recording
     {
         private readonly IUIItem uiItem;
         private readonly Create createUserEvent;
-        private readonly UIItemEventListener eventListener;
+        private readonly IUIItemEventListener eventListener;
         private readonly ILogger logger = CoreAppXmlConfiguration.Instance.LoggerFactory.Create(typeof(SafeAutomationEventHandler));
 
         public delegate UserEvent Create(object[] parameters);
 
-        public SafeAutomationEventHandler(IUIItem uiItem, UIItemEventListener eventListener, Create createUserEvent)
+        public SafeAutomationEventHandler(IUIItem uiItem, IUIItemEventListener eventListener, Create createUserEvent)
         {
             this.uiItem = uiItem;
             this.eventListener = eventListener;

--- a/src/TestStack.White/Recording/UIItemEventListener.cs
+++ b/src/TestStack.White/Recording/UIItemEventListener.cs
@@ -2,7 +2,7 @@ using TestStack.White.UIItemEvents;
 
 namespace TestStack.White.Recording
 {
-    public interface UIItemEventListener
+    public interface IUIItemEventListener
     {
         void EventOccured(UserEvent userEvent);
     }

--- a/src/TestStack.White/UIItems/Button.cs
+++ b/src/TestStack.White/UIItems/Button.cs
@@ -15,7 +15,7 @@ namespace TestStack.White.UIItems
             toggleableItem = new ToggleableItem(this);
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             HookClickEvent(eventListener);
         }

--- a/src/TestStack.White/UIItems/CheckBox.cs
+++ b/src/TestStack.White/UIItems/CheckBox.cs
@@ -48,7 +48,7 @@ namespace TestStack.White.UIItems
             Checked = false;
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate
                           {

--- a/src/TestStack.White/UIItems/Hyperlink.cs
+++ b/src/TestStack.White/UIItems/Hyperlink.cs
@@ -17,7 +17,7 @@ namespace TestStack.White.UIItems
             mouse.Click(new Point((int) x, (int) y), actionListener);
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             HookClickEvent(eventListener);
         }

--- a/src/TestStack.White/UIItems/IUIItem.cs
+++ b/src/TestStack.White/UIItems/IUIItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Windows;
 using System.Windows.Automation;
@@ -11,7 +12,7 @@ using Point = System.Windows.Point;
 
 namespace TestStack.White.UIItems
 {
-    public interface IUIItem : IActionListener
+    public interface IUIItem : IActionListener, IEquatable<IUIItem>
     {
         #region Automation
 
@@ -276,11 +277,11 @@ namespace TestStack.White.UIItems
         bool ValueOfEquals(AutomationProperty property, object compareTo);
 
         /// <summary>
-        /// CHeck if the UI Item equals an object
+        /// Check if the UI Item equals an object
         /// </summary>
-        /// <param name="obj">Object to compare to</param>
+        /// <param name="other">Object to compare to</param>
         /// <returns>Returns <c>true</c> if matches, else <c>false</c></returns>
-        bool Equals(object obj);
+        bool Equals(object other);
 
         /// <summary>
         /// Get the HashCode of the UI Item

--- a/src/TestStack.White/UIItems/IUIItem.cs
+++ b/src/TestStack.White/UIItems/IUIItem.cs
@@ -201,19 +201,19 @@ namespace TestStack.White.UIItems
         void RightClick();
 
         /// <summary>
-        /// Performas a right mouse click at a defined <remarks>Point</remarks>
+        /// Performs a right mouse click at a defined <see cref="Point"/>
         /// </summary>
-        /// <param name="point">Point to mouse right click</param>
+        /// <param name="point">Point where to mouse right click</param>
         void RightClickAt(Point point);
 
         /// <summary>
-        ///Perform keyboard action on this UI Item
+        /// Perform keyboard action on this UI Item
         /// </summary>
         /// <param name="key"></param>
         void KeyIn(KeyboardInput.SpecialKeys key);
 
         /// <summary>
-        /// Sets a value on this UI Item
+        /// Set a value on this UI Item
         /// </summary>
         /// <param name="value">Value to set</param>
         void SetValue(object value);

--- a/src/TestStack.White/UIItems/IUIItem.cs
+++ b/src/TestStack.White/UIItems/IUIItem.cs
@@ -13,83 +13,23 @@ namespace TestStack.White.UIItems
 {
     public interface IUIItem : IActionListener
     {
+        #region Automation
+
         /// <summary>
         /// Should be used only if white doesn't support the feature you are looking for.
         /// Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
         /// </summary>
         AutomationElement AutomationElement { get; }
 
-        bool Enabled { get; }
+        /// <summary>
+        /// The <see cref="WindowsFramework"/> of the UI Item
+        /// </summary>
         WindowsFramework Framework { get; }
-        Point Location { get; }
-        Rect Bounds { get; }
-        string Name { get; }
-        Point ClickablePoint { get; }
-        string AccessKey { get; }
-        string Id { get; }
-        bool Visible { get; }
-        string PrimaryIdentification { get; }
+
+        /// <summary>
+        /// The <see cref="IActionListener"/> of the UI Item
+        /// </summary>
         IActionListener ActionListener { get; }
-        IScrollBars ScrollBars { get; }
-        bool IsOffScreen { get; }
-        bool IsFocussed { get; }
-        Color BorderColor { get; }
-        Bitmap VisibleImage { get; }
-        bool ValueOfEquals(AutomationProperty property, object compareTo);
-        void RightClickAt(Point point);
-        void RightClick();
-        void Focus();
-
-        /// <summary>
-        /// An alternative to use instead of Focus, might sometimes be more reliable
-        /// </summary>
-        void SetForeground();
-
-        void Visit(IWindowControlVisitor windowControlVisitor);
-
-        /// <summary>
-        /// Provides the Error on this UIItem. 
-        /// This would return Error object when this item has ErrorProvider displayed next to it.
-        /// </summary>
-        /// <param name="window"></param>
-        /// <returns></returns>
-        string ErrorProviderMessage(Window window);
-
-        bool NameMatches(string text);
-
-        /// <summary>
-        /// Performs mouse click at the center of this item
-        /// </summary>
-        void Click();
-
-        /// <summary>
-        /// Performs mouse double click at the center of this item
-        /// </summary>
-        void DoubleClick();
-
-        /// <summary>
-        ///Perform keyboard action on this UIItem
-        /// </summary>
-        /// <param name="key"></param>
-        void KeyIn(KeyboardInput.SpecialKeys key);
-
-        bool Equals(object obj);
-        int GetHashCode();
-        string ToString();
-
-        /// <summary>
-        /// Internal to white and intended to be used for white recording
-        /// </summary>
-        void UnHookEvents();
-
-        /// <summary>
-        /// Internal to white and intended to be used for white recording
-        /// </summary>
-        /// <param name="eventListener"></param>
-        void HookEvents(UIItemEventListener eventListener);
-
-        void SetValue(object value);
-        void LogStructure();
 
         /// <summary>
         /// Uses the Raw View provided by UIAutomation to find elements within this UIItem. 
@@ -104,14 +44,256 @@ namespace TestStack.White.UIItems
         /// <returns>null or found AutomationElement</returns>
         AutomationElement GetElement(SearchCriteria searchCriteria);
 
-        void Enter(string value);
+        #endregion
 
+        #region State Properties
+
+        /// <summary>
+        /// Is UI Item Enabled
+        /// </summary>
+        bool Enabled { get; }
+
+        /// <summary>
+        /// Is UI Item Off Screen
+        /// </summary>
+        bool IsOffScreen { get; }
+
+        /// <summary>
+        /// Is UI Item Visible
+        /// </summary>
+        bool Visible { get; }
+
+        /// <summary>
+        /// Is UI Item Focussed
+        /// </summary>
+        bool IsFocussed { get; }
+
+        /// <summary>
+        /// The Status of the UI Item
+        /// </summary>
+        string ItemStatus { get; }
+
+        /// <summary>
+        /// Name of the UI Item
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// ID of the UI Item
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Primary Identification of the UI Item
+        /// </summary>
+        string PrimaryIdentification { get; }
+
+        /// <summary>
+        /// Access Key of the UI Item
+        /// </summary>
+        string AccessKey { get; }
+
+        /// <summary>
+        /// HelpText of the UI Item
+        /// </summary>
+        string HelpText { get; }
+
+        /// <summary>
+        /// <see cref="IScrollBars"/> of the UI Item
+        /// </summary>
+        IScrollBars ScrollBars { get; }
+
+        #endregion
+
+        #region Dimension Properties
+
+        /// <summary>
+        /// <see cref="Point"/> location of the UI Item
+        /// </summary>
+        Point Location { get; }
+
+        /// <summary>
+        /// <see cref="Rect"/> Bounds of the UI Item
+        /// </summary>
+        Rect Bounds { get; }
+
+        /// <summary>
+        /// <see cref="Point"/> ClickablePoint of the UI Item
+        /// </summary>
+        Point ClickablePoint { get; }
+
+        #endregion
+
+        #region Graphics
+
+        /// <summary>
+        /// <see cref="Color"/> of the UI Item Border
+        /// </summary>
+        Color BorderColor { get; }
+
+        /// <summary>
+        /// <see cref="Bitmap"/> representing the VisibleImage of the UI Item
+        /// </summary>
+        Bitmap VisibleImage { get; }
+
+        /// <summary>
+        /// Draw a Highlighting around the UI Item in the Color <see cref="Color.Red"/>
+        /// </summary>
         void DrawHighlight();
+
+        /// <summary>
+        /// Draw a Highlighting around the UI Item in a specific color
+        /// </summary>
+        /// <param name="color">Color of the Highlighting</param>
         void DrawHighlight(Color color);
 
         /// <summary>
-        /// Captures an image of the element
+        /// Capture a <see cref="Bitmap"/> image of the UI Item
         /// </summary>
         Bitmap Capture();
+
+        #endregion
+
+        #region Interaction
+
+        /// <summary>
+        /// Focus the UI Item
+        /// </summary>
+        void Focus();
+
+        /// <summary>
+        /// Bring the UI Item to the Foreground
+        /// </summary>
+        /// <remarks>
+        /// An alternative to use instead of Focus, might sometimes be more reliable
+        /// </remarks>
+        void SetForeground();
+        
+        /// <summary>
+        /// Visit the UI Item
+        /// </summary>
+        /// <param name="windowControlVisitor">Window Control Visitor</param>
+        void Visit(IWindowControlVisitor windowControlVisitor);
+
+        /// <summary>
+        /// Performs an Invoke on the <see cref="InvokePattern"/> Pattern of the UI Item
+        /// </summary>
+        /// <remarks>
+        /// This is faster then a <see cref="Click()"/> on the UI Item.
+        /// Can have some side effects that certain Click Events are bypassed.
+        /// </remarks>
+        void Invoke();
+
+        /// <summary>
+        /// Performs mouse click at the center of the UI Item
+        /// </summary>
+        void Click();
+
+        /// <summary>
+        /// Performs mouse double click at the center of the UI Item
+        /// </summary>
+        void DoubleClick();
+
+        /// <summary>
+        /// Performs a right mouse click at the center of the UI Item
+        /// </summary>
+        void RightClick();
+
+        /// <summary>
+        /// Performas a right mouse click at a defined <remarks>Point</remarks>
+        /// </summary>
+        /// <param name="point">Point to mouse right click</param>
+        void RightClickAt(Point point);
+
+        /// <summary>
+        ///Perform keyboard action on this UI Item
+        /// </summary>
+        /// <param name="key"></param>
+        void KeyIn(KeyboardInput.SpecialKeys key);
+
+        /// <summary>
+        /// Sets a value on this UI Item
+        /// </summary>
+        /// <param name="value">Value to set</param>
+        void SetValue(object value);
+
+        /// <summary>
+        /// Enter a value on this UI Item
+        /// </summary>
+        /// <param name="value">Value to enter</param>
+        /// <remarks>The <see cref="ValuePattern"/> must be supported by the UI Item for this to work</remarks>
+        void Enter(string value);
+
+        #endregion
+
+        #region Recording
+
+        /// <summary>
+        /// Internal to white and intended to be used for white recording
+        /// </summary>
+        void UnHookEvents();
+
+        /// <summary>
+        /// Internal to white and intended to be used for white recording
+        /// </summary>
+        /// <param name="eventListener"></param>
+        void HookEvents(IUIItemEventListener eventListener);
+
+        #endregion
+
+        #region Debugging
+
+        /// <summary>
+        /// Provides the Error on this UIItem. 
+        /// This would return Error object when this item has ErrorProvider displayed next to it.
+        /// </summary>
+        /// <param name="window"></param>
+        /// <returns></returns>
+        string ErrorProviderMessage(Window window);
+
+        /// <summary>
+        /// Log Structure of the UI Item
+        /// </summary>
+        void LogStructure();
+
+        #endregion
+
+        #region Equality
+
+        /// <summary>
+        /// Check if the UI Item name matches a given name
+        /// </summary>
+        /// <param name="text">Name Value to match against</param>
+        /// <returns>Returns <c>true</c> if matches, else <c>false</c></returns>
+        bool NameMatches(string text);
+
+        /// <summary>
+        /// Compare the <see cref="AutomationProperty"/> from the UI Item against an object
+        /// </summary>
+        /// <param name="property">The <see cref="AutomationProperty"/> value to compare to</param>
+        /// <param name="compareTo">The object to compare it to</param>
+        /// <returns>Returns <c>true</c> if matches, else <c>false</c></returns>
+        bool ValueOfEquals(AutomationProperty property, object compareTo);
+
+        /// <summary>
+        /// CHeck if the UI Item equals an object
+        /// </summary>
+        /// <param name="obj">Object to compare to</param>
+        /// <returns>Returns <c>true</c> if matches, else <c>false</c></returns>
+        bool Equals(object obj);
+
+        /// <summary>
+        /// Get the HashCode of the UI Item
+        /// </summary>
+        /// <returns>The HashCode of the UI Item</returns>
+        int GetHashCode();
+        
+        /// <summary>
+        /// ToString overload for the UI Item
+        /// </summary>
+        /// <returns>The String representation of the UI Item</returns>
+        string ToString();
+
+        #endregion
     }
 }

--- a/src/TestStack.White/UIItems/Image.cs
+++ b/src/TestStack.White/UIItems/Image.cs
@@ -9,7 +9,7 @@ namespace TestStack.White.UIItems
         protected Image() {}
         public Image(AutomationElement automationElement, IActionListener actionListener) : base(automationElement, actionListener) {}
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             HookClickEvent(eventListener);
         }

--- a/src/TestStack.White/UIItems/ListBoxItems/ComboBox.cs
+++ b/src/TestStack.White/UIItems/ListBoxItems/ComboBox.cs
@@ -89,7 +89,7 @@ namespace TestStack.White.UIItems.ListBoxItems
                 p.Collapse();
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             lastSelectedItem = SelectedItem;
             handler = delegate(object sender, AutomationPropertyChangedEventArgs e)

--- a/src/TestStack.White/UIItems/ListBoxItems/ListBox.cs
+++ b/src/TestStack.White/UIItems/ListBoxItems/ListBox.cs
@@ -32,7 +32,7 @@ namespace TestStack.White.UIItems.ListBoxItems
             Item(itemText).UnCheck();
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate(object sender, AutomationPropertyChangedEventArgs e)
                           {

--- a/src/TestStack.White/UIItems/ListView.cs
+++ b/src/TestStack.White/UIItems/ListView.cs
@@ -124,7 +124,7 @@ namespace TestStack.White.UIItems
         }
 
         //TODO While recording you get exception when clicking at the corner of the cell
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             var safeAutomationEventHandler =
                 new SafeAutomationEventHandler(this, eventListener, objs => ListViewEvent.Create(this, (AutomationPropertyChangedEventArgs) objs[0]));

--- a/src/TestStack.White/UIItems/RadioButton.cs
+++ b/src/TestStack.White/UIItems/RadioButton.cs
@@ -11,7 +11,7 @@ namespace TestStack.White.UIItems
         protected RadioButton() {}
         public RadioButton(AutomationElement automationElement, IActionListener actionListener) : base(automationElement, actionListener) {}
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate { eventListener.EventOccured(new RadioButtonEvent(this)); };
             Automation.AddAutomationEventHandler(SelectionItemPattern.ElementSelectedEvent, automationElement, TreeScope.Element, handler);

--- a/src/TestStack.White/UIItems/TabItems/Tab.cs
+++ b/src/TestStack.White/UIItems/TabItems/Tab.cs
@@ -59,7 +59,7 @@ namespace TestStack.White.UIItems.TabItems
             if (!oldTab.Equals(SelectedTab)) actionListener.ActionPerformed(new Action(ActionType.NewControls));
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate { eventListener.EventOccured(new TabEvent(this)); };
             Automation.AddAutomationPropertyChangedEventHandler(automationElement, TreeScope.Descendants, handler, SelectionItemPattern.IsSelectedProperty);

--- a/src/TestStack.White/UIItems/TextBox.cs
+++ b/src/TestStack.White/UIItems/TextBox.cs
@@ -77,7 +77,7 @@ namespace TestStack.White.UIItems
             mouse.Click(Bounds.Center(), actionListener);
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate { eventListener.EventOccured(new TextBoxEvent(this)); };
             Automation.AddAutomationPropertyChangedEventHandler(automationElement, TreeScope.Element, handler, ValuePattern.ValueProperty);

--- a/src/TestStack.White/UIItems/TreeItems/Tree.cs
+++ b/src/TestStack.White/UIItems/TreeItems/Tree.cs
@@ -86,7 +86,7 @@ namespace TestStack.White.UIItems.TreeItems
             }
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             clickedTreeNodeHandler = delegate
                                          {

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -446,14 +446,23 @@ namespace TestStack.White.UIItems
         /// <summary>
         /// Implements <see cref="IUIItem.Equals(object)"/>
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object other)
         {
-            if (this == obj)
+            if (other == null)
             {
-                return true;
+                return false;
             }
-            var uiItem = obj as UIItem;
-            return uiItem != null && Equals(automationElement, uiItem.AutomationElement);
+
+            var uiItem = other as IUIItem;
+            return uiItem != null && Equals(uiItem);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IEquatable{T}.Equals(T)"/>
+        /// </summary>
+        public bool Equals(IUIItem other)
+        {
+            return other != null && Equals(automationElement, other.AutomationElement);
         }
 
         /// <summary>
@@ -463,7 +472,7 @@ namespace TestStack.White.UIItems
         {
             return automationElement.GetHashCode();
         }
-
+        
         /// <summary>
         /// Implements <see cref="IUIItem.ToString()"/>
         /// </summary>

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -27,6 +27,8 @@ namespace TestStack.White.UIItems
     //TODO ToolStrip and Similar kind of support
     public class UIItem : IUIItem
     {
+        #region Fields
+
         protected readonly AutomationElement automationElement;
         protected IActionListener actionListener;
         internal static readonly Mouse mouse = Mouse.Instance;
@@ -35,6 +37,10 @@ namespace TestStack.White.UIItems
         protected IScrollBars scrollBars;
         private AutomationEventHandler handler;
         protected readonly ILogger Logger = CoreAppXmlConfiguration.Instance.LoggerFactory.Create(typeof(UIItem));
+
+        #endregion
+
+        #region Constructor
 
         protected UIItem()
         {
@@ -48,45 +54,88 @@ namespace TestStack.White.UIItems
             factory = new PrimaryUIItemFactory(new AutomationElementFinder(automationElement));
         }
 
+        #endregion
+
+        #region Automation 
+
         /// <summary>
-        /// Should be used only if white doesn't support the feature you are looking for.
-        /// Knowledge of UIAutomation would be required. It would better idea to also raise an issue if you are using it.
+        /// Implements <see cref="IUIItem.AutomationElement"/>
         /// </summary>
         public virtual AutomationElement AutomationElement
         {
             get { return automationElement; }
         }
 
-        protected virtual object Property(AutomationProperty automationProperty)
-        {
-            return automationElement.GetCurrentPropertyValue(automationProperty);
-        }
-
-        public virtual bool Enabled
-        {
-            get { return automationElement.Current.IsEnabled; }
-        }
-
+        /// <summary>
+        /// Implements <see cref="IUIItem.Framework"/>
+        /// </summary>
         public virtual WindowsFramework Framework
         {
             get { return WindowsFrameworkExtensions.FromFrameworkId(automationElement.Current.FrameworkId); }
         }
 
-        public virtual Point Location
+        /// <summary>
+        /// Implements <see cref="IUIItem.ActionListener"/>
+        /// </summary>
+        public virtual IActionListener ActionListener
         {
-            get { return automationElement.Current.BoundingRectangle.TopLeft; }
+            get { return actionListener; }
         }
 
-        protected virtual void ActionPerformed()
+        /// <summary>
+        /// Implements <see cref="IUIItem.GetElement(SearchCriteria)"/>
+        /// </summary>
+        public virtual AutomationElement GetElement(SearchCriteria searchCriteria)
         {
-            actionListener.ActionPerformed(Action.WindowMessage);
+            return
+                new AutomationElementFinder(automationElement).FindDescendantRaw(
+                    searchCriteria.AutomationSearchCondition);
         }
 
-        public virtual Rect Bounds
+        #endregion
+
+        #region State Properties
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Enabled"/>
+        /// </summary>
+        public virtual bool Enabled
         {
-            get { return automationElement.Current.BoundingRectangle; }
+            get { return automationElement.Current.IsEnabled; }
         }
 
+        /// <summary>
+        /// Implements <see cref="IUIItem.IsOffScreen"/>
+        /// </summary>
+        public virtual bool IsOffScreen
+        {
+            get { return automationElement.Current.IsOffscreen; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Visible"/>
+        /// </summary>
+        public virtual bool Visible
+        {
+            get { return !automationElement.Current.IsOffscreen; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.IsFocussed"/>
+        /// </summary>
+        public virtual bool IsFocussed
+        {
+            get { return automationElement.Current.HasKeyboardFocus; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.ItemStatus"/>
+        /// </summary>
+        public virtual string ItemStatus { get { return automationElement.Current.ItemStatus; } }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Name"/>
+        /// </summary>
         public virtual string Name
         {
             get
@@ -102,19 +151,401 @@ namespace TestStack.White.UIItems
             }
         }
 
-        public virtual Point ClickablePoint
+        /// <summary>
+        /// Implements <see cref="IUIItem.Id"/>
+        /// </summary>
+        public virtual string Id
         {
-            get { return (Point)Property(AutomationElement.ClickablePointProperty); }
+            get { return automationElement.Current.AutomationId; }
         }
 
+        /// <summary>
+        /// Implements <see cref="IUIItem.PrimaryIdentification"/>
+        /// </summary>
+        public virtual string PrimaryIdentification
+        {
+            get { return automationElement.Current.FrameworkId.Equals(WindowsFramework.Win32.FrameworkId()) ? Name : Id; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.HelpText"/>
+        /// </summary>
+        public virtual string HelpText { get { return automationElement.Current.HelpText; } }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.AccessKey"/>
+        /// </summary>
         public virtual string AccessKey
         {
             get { return automationElement.Current.AccessKey; }
         }
 
+        /// <summary>
+        /// Implements <see cref="IUIItem.ScrollBars"/>
+        /// </summary>
+        public virtual IScrollBars ScrollBars
+        {
+            get { return scrollBars ?? (scrollBars = ScrollerFactory.CreateBars(automationElement, actionListener)); }
+        }
+
+        #endregion
+
+        #region Dimension Properties
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Location"/>
+        /// </summary>
+        public virtual Point Location
+        {
+            get { return automationElement.Current.BoundingRectangle.TopLeft; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Bounds"/>
+        /// </summary>
+        public virtual Rect Bounds
+        {
+            get { return automationElement.Current.BoundingRectangle; }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.ClickablePoint"/>
+        /// </summary>
+        public virtual Point ClickablePoint
+        {
+            get { return (Point)Property(AutomationElement.ClickablePointProperty); }
+        }
+        #endregion
+
+        #region Graphics
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.BorderColor"/>
+        /// </summary>
+        public virtual Color BorderColor
+        {
+            get { return VisibleImage.GetPixel(0, 0); }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.VisibleImage"/>
+        /// </summary>
+        public virtual Bitmap VisibleImage
+        {
+            get
+            {
+                var displayedItem = new DisplayedItem(new IntPtr(automationElement.Current.NativeWindowHandle));
+                using (System.Drawing.Image image = displayedItem.GetVisibleImage())
+                    return new Bitmap(image);
+            }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.DrawHighlight()"/>
+        /// </summary>
+        public virtual void DrawHighlight()
+        {
+            DrawHighlight(Color.Red);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.DrawHighlight(Color)"/>
+        /// </summary>
+        public virtual void DrawHighlight(Color color)
+        {
+            var rectangle = AutomationElement.Current.BoundingRectangle;
+            if (rectangle != Rect.Empty)
+            {
+                new Drawing.FrameRectangle(color, rectangle).Highlight();
+            }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Capture"/>
+        /// </summary>
+        public virtual Bitmap Capture()
+        {
+            return Desktop.CaptureScreenshot(Bounds);
+        }
+
+        #endregion
+
+        #region Interaction
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Focus"/>
+        /// </summary>
+        public virtual void Focus()
+        {
+            actionListener.ActionPerforming(this);
+            try
+            {
+                automationElement.SetFocus();
+                ActionPerformed();
+            }
+            catch
+            {
+                Logger.Debug("Could not set focus on " + AutomationElement.Display());
+            }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.SetForeground"/>
+        /// </summary>
+        public virtual void SetForeground()
+        {
+            NativeWindow.SetForegroundWindow(new IntPtr(automationElement.Current.NativeWindowHandle));
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Visit"/>
+        /// </summary>
+        public virtual void Visit(IWindowControlVisitor windowControlVisitor)
+        {
+            windowControlVisitor.Accept(this);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Invoke"/>
+        /// </summary>
+        public virtual void Invoke()
+        {
+            var invokePattern = (InvokePattern)Pattern(InvokePattern.Pattern);
+            if (invokePattern != null) invokePattern.Invoke();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Click"/>
+        /// </summary>
+        public virtual void Click()
+        {
+            actionListener.ActionPerforming(this);
+            PerformIfValid(PerformClick);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.DoubleClick"/>
+        /// </summary>
+        public virtual void DoubleClick()
+        {
+            actionListener.ActionPerforming(this);
+            PerformIfValid(() => mouse.DoubleClick(Bounds.Center(), actionListener));
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.RightClick()"/>
+        /// </summary>
+        public virtual void RightClick()
+        {
+            RightClickOnCenter();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.RightClickAt(Point)"/>
+        /// </summary>
+        public virtual void RightClickAt(Point point)
+        {
+            actionListener.ActionPerforming(this);
+            mouse.RightClick(point, actionListener);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.KeyIn"/>
+        /// </summary>
+        public virtual void KeyIn(KeyboardInput.SpecialKeys key)
+        {
+            actionListener.ActionPerforming(this);
+            keyboard.PressSpecialKey(key, actionListener);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.SetValue"/>
+        /// </summary>
+        public virtual void SetValue(object value)
+        {
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Enter"/>
+        /// </summary>
+        public virtual void Enter(string value)
+        {
+            var pattern = Pattern(ValuePattern.Pattern) as ValuePattern;
+            if (pattern != null) pattern.SetValue(string.Empty);
+            if (string.IsNullOrEmpty(value)) return;
+
+            actionListener.ActionPerformed(Action.WindowMessage);
+            EnterData(value);
+        }
+
+        #endregion
+
+        #region Recording
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.UnHookEvents"/>
+        /// </summary>
+        public virtual void UnHookEvents()
+        {
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.HookEvents"/>
+        /// </summary>
+        public virtual void HookEvents(IUIItemEventListener eventListener)
+        {
+        }
+
+        #endregion
+
+        #region Debugging
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.ErrorProviderMessage"/>
+        /// </summary>
+        public virtual string ErrorProviderMessage(Window window)
+        {
+            var element =
+                AutomationElement.FromPoint(automationElement.Current.BoundingRectangle.ImmediateExteriorEast());
+            if (element == null) return null;
+            var errorProviderBounds = element.Current.BoundingRectangle;
+            if (automationElement.Current.BoundingRectangle.Right != errorProviderBounds.Left) return null;
+            mouse.Location = errorProviderBounds.Center();
+            actionListener.ActionPerformed(Action.WindowMessage);
+            return window.ToolTip.Text;
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.LogStructure"/>
+        /// </summary>
+        public virtual void LogStructure()
+        {
+            Logger.Info(Debug.Details(AutomationElement));
+        }
+
+        #endregion
+
+        #region Equality
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.NameMatches"/>
+        /// </summary>
+        public virtual bool NameMatches(string text)
+        {
+            return Name.Equals(text);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.ValueOfEquals"/>
+        /// </summary>
         public virtual bool ValueOfEquals(AutomationProperty property, object compareTo)
         {
             return Property(property).Equals(compareTo);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.Equals(object)"/>
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+            var uiItem = obj as UIItem;
+            return uiItem != null && Equals(automationElement, uiItem.AutomationElement);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.GetHashCode()"/>
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return automationElement.GetHashCode();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IUIItem.ToString()"/>
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Format("{0}. {1}", GetType().Name, automationElement.Display());
+        }
+
+        #endregion
+
+        #region Implementation from IActionListener
+
+        /// <summary>
+        /// Implements <see cref="IActionListener.ActionPerforming"/>
+        /// </summary>
+        public virtual void ActionPerforming(UIItem uiItem)
+        {
+        }
+
+        /// <summary>
+        /// Implements <see cref="IActionListener.ActionPerformed"/>
+        /// </summary>
+        public virtual void ActionPerformed(Action action)
+        {
+            actionListener.ActionPerformed(action);
+        }
+        
+        #endregion
+
+        #region Public
+
+        /// <summary>
+        /// Make an <see cref="IUIItemContainer"/> out of the <see cref="IUIItem"/>
+        /// </summary>
+        /// <returns>Returns an <c><see cref="IUIItemContainer"/></c> if possibe</returns>
+        public virtual IUIItemContainer AsContainer()
+        {
+            if (Framework != WindowsFramework.Wpf)
+            {
+                Logger.Warn("Only WPF items should be treated as container items");
+                throw new WhiteException(string.Format(
+                        "Cannot create a Container since the UI Item is not of the correct Framework Type {0}",
+                        WindowsFramework.Wpf));
+            }
+            return new UIItemContainer(AutomationElement, ActionListener);
+        }
+        
+        #endregion
+        
+        #region Protected
+
+        protected virtual void ActionPerformed()
+        {
+            actionListener.ActionPerformed(Action.WindowMessage);
+        }
+
+        protected virtual void EnterData(string value)
+        {
+            var lines = value.Replace("\r\n", "\n").Split('\n');
+            keyboard.Send(lines[0], actionListener);
+            foreach (var line in lines.Skip(1))
+            {
+                keyboard.PressSpecialKey(KeyboardInput.SpecialKeys.RETURN);
+                keyboard.Send(line, actionListener);
+            }
+        }
+
+        protected virtual void HookClickEvent(IUIItemEventListener eventListener)
+        {
+            handler = delegate { eventListener.EventOccured(new UIItemClickEvent(this)); };
+            Automation.AddAutomationEventHandler(InvokePattern.InvokedEvent, automationElement, TreeScope.Element,
+                                                 handler);
+        }
+
+        protected virtual void UnHookClickEvent()
+        {
+            Automation.RemoveAutomationEventHandler(InvokePattern.InvokedEvent, automationElement, handler);
+        }
+
+        protected virtual object Property(AutomationProperty automationProperty)
+        {
+            return automationElement.GetCurrentPropertyValue(automationProperty);
         }
 
         protected virtual T Pattern<T>()
@@ -134,6 +565,10 @@ namespace TestStack.White.UIItems
             return Pattern(AutomationElement, pattern);
         }
 
+        #endregion
+
+        #region Internal
+
         internal static BasePattern Pattern(AutomationElement automationElement, AutomationPattern pattern)
         {
             object patternObject;
@@ -144,95 +579,13 @@ namespace TestStack.White.UIItems
             return null;
         }
 
-        public virtual void RightClickAt(Point point)
-        {
-            actionListener.ActionPerforming(this);
-            mouse.RightClick(point, actionListener);
-        }
-
-        public virtual void RightClick()
-        {
-            RightClickOnCenter();
-        }
+        #endregion
+        
+        #region Private
 
         private void RightClickOnCenter()
         {
             RightClickAt(Bounds.Center());
-        }
-
-        public virtual void Focus()
-        {
-            actionListener.ActionPerforming(this);
-            try
-            {
-                automationElement.SetFocus();
-                ActionPerformed();
-            }
-            catch
-            {
-                Logger.Debug("Could not set focus on " + AutomationElement.Display());
-            }
-        }
-
-        public virtual void SetForeground()
-        {
-            WindowsAPI.NativeWindow.SetForegroundWindow(new IntPtr(automationElement.Current.NativeWindowHandle));
-        }
-
-        public virtual void Visit(IWindowControlVisitor windowControlVisitor)
-        {
-            windowControlVisitor.Accept(this);
-        }
-
-        public virtual string Id
-        {
-            get { return automationElement.Current.AutomationId; }
-        }
-
-        public virtual bool Visible
-        {
-            get { return !automationElement.Current.IsOffscreen; }
-        }
-
-        /// <summary>
-        /// Provides the Error on this UIItem. This would return Error object when this item has ErrorProvider displayed next to it.
-        /// </summary>
-        /// <param name="window"></param>
-        /// <returns></returns>
-        public virtual string ErrorProviderMessage(Window window)
-        {
-            var element =
-                AutomationElement.FromPoint(automationElement.Current.BoundingRectangle.ImmediateExteriorEast());
-            if (element == null) return null;
-            var errorProviderBounds = element.Current.BoundingRectangle;
-            if (automationElement.Current.BoundingRectangle.Right != errorProviderBounds.Left) return null;
-            mouse.Location = errorProviderBounds.Center();
-            actionListener.ActionPerformed(Action.WindowMessage);
-            return window.ToolTip.Text;
-        }
-
-        public virtual bool NameMatches(string text)
-        {
-            return Name.Equals(text);
-        }
-
-        public virtual string PrimaryIdentification
-        {
-            get { return automationElement.Current.FrameworkId.Equals(WindowsFramework.Win32.FrameworkId()) ? Name : Id; }
-        }
-
-        public virtual IActionListener ActionListener
-        {
-            get { return actionListener; }
-        }
-
-        /// <summary>
-        /// Performs mouse click at the center of this item
-        /// </summary>
-        public virtual void Click()
-        {
-            actionListener.ActionPerforming(this);
-            PerformIfValid(PerformClick);
         }
 
         private void PerformIfValid(System.Action action)
@@ -258,7 +611,7 @@ namespace TestStack.White.UIItems
             throw new AutomationException(string.Format("Cannot perform action on {0}, {1}", this, message), Debug.Details(AutomationElement));
         }
 
-        void PerformClick()
+        private void PerformClick()
         {
             if (!Enabled) Logger.WarnFormat("Clicked on disabled item: {0}", ToString());
             var bounds = Bounds;
@@ -269,202 +622,6 @@ namespace TestStack.White.UIItems
             mouse.Click(bounds.Center(), actionListener);
         }
 
-        /// <summary>
-        /// Performs mouse double click at the center of this item
-        /// </summary>
-        public virtual void DoubleClick()
-        {
-            actionListener.ActionPerforming(this);
-            PerformIfValid(() => mouse.DoubleClick(Bounds.Center(), actionListener));
-        }
-
-        /// <summary>
-        /// Perform keyboard action on this UIItem
-        /// </summary>
-        /// <param name="key"></param>
-        public virtual void KeyIn(KeyboardInput.SpecialKeys key)
-        {
-            actionListener.ActionPerforming(this);
-            keyboard.PressSpecialKey(key, actionListener);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (this == obj) return true;
-            var uiItem = obj as UIItem;
-            if (uiItem == null) return false;
-            return Equals(automationElement, uiItem.AutomationElement);
-        }
-
-        public override int GetHashCode()
-        {
-            return automationElement.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            return string.Format("{0}. {1}", GetType().Name, automationElement.Display());
-        }
-
-        public virtual IScrollBars ScrollBars
-        {
-            get { return scrollBars ?? (scrollBars = ScrollerFactory.CreateBars(automationElement, actionListener)); }
-        }
-
-        protected virtual void HookClickEvent(UIItemEventListener eventListener)
-        {
-            handler = delegate { eventListener.EventOccured(new UIItemClickEvent(this)); };
-            Automation.AddAutomationEventHandler(InvokePattern.InvokedEvent, automationElement, TreeScope.Element,
-                                                 handler);
-        }
-
-        protected virtual void UnHookClickEvent()
-        {
-            Automation.RemoveAutomationEventHandler(InvokePattern.InvokedEvent, automationElement, handler);
-        }
-
-        public virtual bool IsOffScreen
-        {
-            get { return automationElement.Current.IsOffscreen; }
-        }
-
-        public virtual bool IsFocussed
-        {
-            get { return automationElement.Current.HasKeyboardFocus; }
-        }
-
-        public virtual Color BorderColor
-        {
-            get { return VisibleImage.GetPixel(0, 0); }
-        }
-
-        public virtual Bitmap VisibleImage
-        {
-            get
-            {
-                var displayedItem = new DisplayedItem(new IntPtr(automationElement.Current.NativeWindowHandle));
-                using (System.Drawing.Image image = displayedItem.GetVisibleImage())
-                    return new Bitmap(image);
-            }
-        }
-
-        public virtual string HelpText { get { return automationElement.Current.HelpText; } }
-
-        public virtual string ItemStatus { get { return automationElement.Current.ItemStatus; } }
-
-        /// <summary>
-        /// Internal to white and intended to be used for white recording
-        /// </summary>
-        public virtual void UnHookEvents()
-        {
-        }
-
-        /// <summary>
-        /// Internal to white and intended to be used for white recording
-        /// </summary>
-        /// <param name="eventListener"></param>
-        public virtual void HookEvents(UIItemEventListener eventListener)
-        {
-        }
-
-        public virtual void SetValue(object value)
-        {
-        }
-
-        public virtual void ActionPerforming(UIItem uiItem)
-        {
-        }
-
-        public virtual void ActionPerformed(Action action)
-        {
-            actionListener.ActionPerformed(action);
-        }
-
-        public virtual void LogStructure()
-        {
-            Logger.Info(Debug.Details(AutomationElement));
-        }
-
-        /// <summary>
-        /// Uses the Raw View provided by UIAutomation to find elements within this UIItem. RawView sometimes contains extra AutomationElements. This is internal to 
-        /// white although made public. Should be used only if the standard approaches dont work. Also if you end up using it please raise an issue
-        /// so that it can be fixed.
-        /// Please understand that calling this method on any UIItem which has a lot of child AutomationElements might result in very bad performance.
-        /// </summary>
-        /// <param name="searchCriteria"></param>
-        /// <returns>null or found AutomationElement</returns>
-        public virtual AutomationElement GetElement(SearchCriteria searchCriteria)
-        {
-            return
-                new AutomationElementFinder(automationElement).FindDescendantRaw(
-                    searchCriteria.AutomationSearchCondition);
-        }
-
-        public virtual void Enter(string value)
-        {
-            var pattern = Pattern(ValuePattern.Pattern) as ValuePattern;
-            if (pattern != null) pattern.SetValue(string.Empty);
-            if (string.IsNullOrEmpty(value)) return;
-
-            actionListener.ActionPerformed(Action.WindowMessage);
-            EnterData(value);
-        }
-
-        protected virtual void EnterData(string value)
-        {
-            var lines = value.Replace("\r\n", "\n").Split('\n');
-            keyboard.Send(lines[0], actionListener);
-            foreach (var line in lines.Skip(1))
-            {
-                keyboard.PressSpecialKey(KeyboardInput.SpecialKeys.RETURN);
-                keyboard.Send(line, actionListener);
-            }
-        }
-
-        /// <summary>
-        /// Make an <see cref="IUIItemContainer"/> out of the <see cref="IUIItem"/>
-        /// </summary>
-        /// <returns>Returns an <c><see cref="IUIItemContainer"/></c> if possibe</returns>
-        public virtual IUIItemContainer AsContainer()
-        {
-            if (Framework != WindowsFramework.Wpf)
-            {
-                Logger.Warn("Only WPF items should be treated as container items");
-                throw new WhiteException(string.Format(
-                        "Cannot create a Container since the UI Item is not of the correct Framework Type {0}",
-                        WindowsFramework.Wpf));
-            }
-            return new UIItemContainer(AutomationElement, ActionListener);
-        }
-
-        public virtual void RaiseClickEvent()
-        {
-            var invokePattern = (InvokePattern)Pattern(InvokePattern.Pattern);
-            if (invokePattern != null) invokePattern.Invoke();
-        }
-
-        /// <summary>
-        /// Highlight UIItem with a red frame
-        /// </summary>
-        public virtual void DrawHighlight()
-        {
-            DrawHighlight(Color.Red);
-        }
-        /// <summary>
-        /// Highlight UIItem with a colored frame
-        /// </summary>
-        public virtual void DrawHighlight(Color color)
-        {
-            var rectangle = AutomationElement.Current.BoundingRectangle;
-            if (rectangle != Rect.Empty)
-            {
-                new Drawing.FrameRectangle(color, rectangle).Highlight();
-            }
-        }
-
-        public virtual Bitmap Capture()
-        {
-            return Desktop.CaptureScreenshot(Bounds);
-        }
+        #endregion
     }
 }

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -337,7 +337,7 @@ namespace TestStack.White.UIItems
         /// </summary>
         public virtual void RightClick()
         {
-            RightClickOnCenter();
+            RightClickAt(Bounds.Center());
         }
 
         /// <summary>
@@ -591,11 +591,6 @@ namespace TestStack.White.UIItems
         #endregion
         
         #region Private
-
-        private void RightClickOnCenter()
-        {
-            RightClickAt(Bounds.Center());
-        }
 
         private void PerformIfValid(System.Action action)
         {

--- a/src/TestStack.White/UIItems/WindowItems/Window.cs
+++ b/src/TestStack.White/UIItems/WindowItems/Window.cs
@@ -293,7 +293,7 @@ UI actions on window needing mouse would not work in area not falling under the 
 
         public override void Visit(IWindowControlVisitor windowControlVisitor)
         {
-            windowControlVisitor.Accept(this);
+            base.Visit(windowControlVisitor);
             CurrentContainerItemFactory.Visit(windowControlVisitor);
         }
 
@@ -346,7 +346,7 @@ UI actions on window needing mouse would not work in area not falling under the 
                    (DisplayState.Minimized == value && !WinPattern.Current.CanMinimize);
         }
 
-        public override void HookEvents(UIItemEventListener eventListener)
+        public override void HookEvents(IUIItemEventListener eventListener)
         {
             handler = delegate { };
             Automation.AddAutomationEventHandler(AutomationElement.MenuOpenedEvent, automationElement,


### PR DESCRIPTION
Cleaning Up UIItem and IUIItem

- Adding Regions for sets of Functionality such as 'Interaction with an
UI Item', 'Properties of an UI Item', etc
- Renamed the RaiseClickEvent to Invoke
- Added code documentation
- Moved some public properties and functions also into the Interface to
get the Interface and implementing class in Synch

- Renamed UIItemEventListener to IUIItemEventListener

!! Migration Note !!
- Renamed the IUIItem.RaiseClickEvent to IUIItem.Invoke
- Renamed UIItemEventListener  to IUIItemEventListener 