### PR TITLE
IMouse / Mouse refactoring

### DIFF
--- a/src/TestStack.White.UITests/InputDevices/DragAndDropTests.cs
+++ b/src/TestStack.White.UITests/InputDevices/DragAndDropTests.cs
@@ -23,7 +23,8 @@ namespace TestStack.White.UITests.InputDevices
             {
                 var button = window.Get<Button>("Button");
                 var textBox = window.Get<TextBox>("TextBox");
-                Mouse.Instance.DragAndDrop(textBox, textBox.Bounds.Center(), button, button.Bounds.Center());
+                var mouse = new Mouse();
+                mouse.DragAndDrop(textBox, textBox.Bounds.Center(), button, button.Bounds.Center());
 
                 Retry.For(() => Assert.That(window.Get<Label>("DragDropResults").Text, Is.EqualTo("TextBoxDraggedOntoButton")),
                     TimeSpan.FromSeconds(2));
@@ -37,7 +38,8 @@ namespace TestStack.White.UITests.InputDevices
             {
                 var button = window.Get<Button>("Button");
                 var textBox = window.Get<TextBox>("TextBox");
-                Mouse.Instance.DragAndDrop(textBox, button);
+                var mouse = new Mouse();
+                mouse.DragAndDrop(textBox, button);
 
                 Retry.For(() => Assert.That(window.Get<Label>("DragDropResults").Text, Is.EqualTo("TextBoxDraggedOntoButton")),
                     TimeSpan.FromSeconds(2));

--- a/src/TestStack.White.UITests/InputDevices/MouseTests.cs
+++ b/src/TestStack.White.UITests/InputDevices/MouseTests.cs
@@ -20,14 +20,15 @@ namespace TestStack.White.UITests.InputDevices
         [Test]
         public void CursorTest()
         {
-            var cursor = Mouse.Instance.Cursor;
+            var mouse = new Mouse();
+            var cursor = mouse.Cursor;
             Assert.That(cursor, Is.Not.Null);
         }
 
         [Test]
         public void LocationTest()
         {
-            var mouse = Mouse.Instance;
+            var mouse = new Mouse();
             var point = new Point(100, 100);
             Assert.That(mouse.Location, Is.Not.EqualTo(point));
             mouse.Location = point;
@@ -38,8 +39,8 @@ namespace TestStack.White.UITests.InputDevices
         public void RightClickTest()
         {
             var button = MainWindow.Get<Button>("ButtonWithTooltip");
-            Mouse.Instance.Location = button.Bounds.Center();
-            Mouse.Instance.RightClick();
+            var mouse = new Mouse {Location = button.Bounds.Center()};
+            mouse.RightClick();
             Retry.For(() => Assert.That(button.Text, Is.EqualTo("Right click received")), TimeSpan.FromSeconds(5));
         }
     }

--- a/src/TestStack.White.WebBrowser.UITests/Silverlight/SilverlightDocumentTest.cs
+++ b/src/TestStack.White.WebBrowser.UITests/Silverlight/SilverlightDocumentTest.cs
@@ -71,7 +71,8 @@ namespace TestStack.White.WebBrowser.UITests.Silverlight
             var comboBox = document.Get<ComboBox>("combo");
             comboBox.Select("foo");
             comboBox.Select("foo");
-            Mouse.Instance.LeftClick(button.Bounds.Center(), document);
+            var mouse = new Mouse();
+            mouse.LeftClick(button.Bounds.Center(), document);
             Assert.That(label.Text, Is.Not.EqualTo(previousText));
         }
     }

--- a/src/TestStack.White.WebBrowser.UITests/Silverlight/SilverlightDocumentTest.cs
+++ b/src/TestStack.White.WebBrowser.UITests/Silverlight/SilverlightDocumentTest.cs
@@ -71,7 +71,7 @@ namespace TestStack.White.WebBrowser.UITests.Silverlight
             var comboBox = document.Get<ComboBox>("combo");
             comboBox.Select("foo");
             comboBox.Select("foo");
-            Mouse.Instance.Click(button.Bounds.Center(), document);
+            Mouse.Instance.LeftClick(button.Bounds.Center(), document);
             Assert.That(label.Text, Is.Not.EqualTo(previousText));
         }
     }

--- a/src/TestStack.White.sln
+++ b/src/TestStack.White.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1BCBA4C4-8C47-496C-B0D4-FDE9D066ED27}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/TestStack.White/InputDevices/AttachedMouse.cs
+++ b/src/TestStack.White/InputDevices/AttachedMouse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using TestStack.White.UIItems;
 using TestStack.White.UIItems.Actions;
@@ -23,6 +24,8 @@ namespace TestStack.White.InputDevices
 
         #endregion
 
+        #region Mouse Properties
+
         /// <summary>
         /// Implements <see cref="IBaseMouse.Location"/>
         /// </summary>
@@ -32,30 +35,30 @@ namespace TestStack.White.InputDevices
             set { mouse.Location = value; }
         }
 
-        public MouseCursor Cursor
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Cursor"/>
+        /// </summary>
+        public virtual MouseCursor Cursor
         {
             get { return mouse.Cursor; }
         }
 
-        #region Mouse Click
+        #endregion
 
-        public void Click()
-        {
-            mouse.Click();
-            ActionPerformed();
-        }
+        #region Click
 
-        public void Click(Point point)
-        {
-            mouse.Click(point, actionListener);
-        }
-
-        public void Click(MouseButton mouseButton)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(MouseButton)"/>
+        /// </summary>
+        public virtual void Click(MouseButton mouseButton)
         {
             mouse.Click(mouseButton, actionListener);
         }
 
-        public void Click(MouseButton mouseButton, Point point)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(MouseButton, Point)"/>
+        /// </summary>
+        public virtual void Click(MouseButton mouseButton, Point point)
         {
             mouse.Click(mouseButton, point, actionListener);
         }
@@ -64,32 +67,121 @@ namespace TestStack.White.InputDevices
 
         #region Double Click
 
-        public void DoubleClick(Point point)
-        {
-            mouse.DoubleClick(point, actionListener);
-        }
-
-        public void DoubleClick(MouseButton mouseButton)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton)"/>
+        /// </summary>
+        public virtual void DoubleClick(MouseButton mouseButton)
         {
             mouse.DoubleClick(mouseButton, actionListener);
         }
 
-        public void DoubleClick(MouseButton mouseButton, Point point)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton, Point)"/>
+        /// </summary>
+        public virtual void DoubleClick(MouseButton mouseButton, Point point)
         {
             mouse.DoubleClick(mouseButton, point, actionListener);
         }
 
         #endregion
 
-        #region Right Click
+        #region Left Click
 
-        public void RightClick()
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click()"/>
+        /// </summary
+        [Obsolete("Use LeftClick instead")]
+        public virtual void Click()
+        {
+            mouse.Click();
+            ActionPerformed();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(Point)"/>
+        /// </summary
+        [Obsolete("Use LeftClick instead")]
+        public virtual void Click(Point point)
+        {
+            mouse.Click(point, actionListener);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftClick()"/>
+        /// </summary
+        public virtual void LeftClick()
+        {
+            mouse.LeftClick();
+            ActionPerformed();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftClick(Point)"/>
+        /// </summary
+        public virtual void LeftClick(Point point)
+        {
+            mouse.LeftClick(point, actionListener);
+        }
+
+        #endregion
+
+        #region Left Double Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick()"/>
+        /// </summary
+        [Obsolete("Use LeftDoubleClick instead")]
+        public virtual void DoubleClick()
+        {
+            mouse.DoubleClick();
+            ActionPerformed();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(Point)"/>
+        /// </summary
+        [Obsolete("Use LeftDoubleClick instead")]
+        public virtual void DoubleClick(Point point)
+        {
+            mouse.DoubleClick(point);
+            ActionPerformed();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftDoubleClick()"/>
+        /// </summary
+        public virtual void LeftDoubleClick()
+        {
+            mouse.LeftDoubleClick();
+            ActionPerformed();
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftDoubleClick(Point)"/>
+        /// </summary
+        public virtual void LeftDoubleClick(Point point)
+        {
+            mouse.LeftDoubleClick(point);
+            ActionPerformed();
+        }
+
+        #endregion
+
+        #region Right Click
+        
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.RightClick(Point)"/>
+        /// </summary
+        public virtual void RightClick()
         {
             mouse.RightClick();
             ActionPerformed();
         }
 
-        public void RightClick(Point point)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.RightClick(Point)"/>
+        /// </summary
+        public virtual void RightClick(Point point)
         {
             mouse.RightClick(point, actionListener);
         }
@@ -98,25 +190,37 @@ namespace TestStack.White.InputDevices
 
         #region Drag And Drop
 
-        public void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, IUIItem)"/>
+        /// </summary
+        public virtual void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
         {
             mouse.DragAndDrop(draggedItem, dropItem);
             ActionPerformed();
         }
 
-        public void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(MouseButton, IUIItem, IUIItem)"/>
+        /// </summary
+        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem)
         {
             mouse.DragAndDrop(mouseButton, draggedItem, dropItem);
             ActionPerformed();
         }
 
-        public void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, Point, IUIItem, Point)"/>
+        /// </summary
+        public virtual void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
         {
             mouse.DragAndDrop(draggedItem, startPosition, dropItem, endPosition);
             ActionPerformed();
         }
 
-        public void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(MouseButton, IUIItem, Point, IUIItem, Point)"/>
+        /// </summary
+        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
         {
             mouse.DragAndDrop(mouseButton,  draggedItem, startPosition, dropItem, endPosition);
             ActionPerformed();
@@ -126,25 +230,37 @@ namespace TestStack.White.InputDevices
 
         #region Drag
 
-        public void DragHorizontally(IUIItem uiItem, int distance)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragHorizontally(IUIItem, int)"/>
+        /// </summary
+        public virtual void DragHorizontally(IUIItem uiItem, int distance)
         {
             mouse.DragHorizontally(uiItem, distance);
             ActionPerformed();
         }
 
-        public void DragHorizontally(MouseButton mouseButton, IUIItem uiItem, int distance)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragHorizontally(MouseButton, IUIItem, int)"/>
+        /// </summary
+        public virtual void DragHorizontally(MouseButton mouseButton, IUIItem uiItem, int distance)
         {
             mouse.DragHorizontally(mouseButton, uiItem, distance);
             ActionPerformed();
         }
 
-        public void DragVertically(IUIItem uiItem, int distance)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragVertically(IUIItem, int)"/>
+        /// </summary
+        public virtual void DragVertically(IUIItem uiItem, int distance)
         {
             mouse.DragVertically(uiItem, distance);
             ActionPerformed();
         }
 
-        public void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragVertically(MouseButton, IUIItem, int)"/>
+        /// </summary
+        public virtual void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance)
         {
             mouse.DragVertically(mouseButton, uiItem, distance);
             ActionPerformed();
@@ -152,13 +268,19 @@ namespace TestStack.White.InputDevices
 
         #endregion
 
-        public void MoveOut()
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.MoveOut()"/>
+        /// </summary
+        public virtual void MoveOut()
         {
             mouse.MoveOut();
             ActionPerformed();
         }
 
-        public void Move(Point position)
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Move(Point)"/>
+        /// </summary
+        public virtual void Move(Point position)
         {
             mouse.Move(position);
             ActionPerformed();
@@ -166,7 +288,7 @@ namespace TestStack.White.InputDevices
 
         #region Protected
 
-        protected void ActionPerformed()
+        protected virtual void ActionPerformed()
         {
             mouse.ActionPerformed(actionListener);
         }

--- a/src/TestStack.White/InputDevices/AttachedMouse.cs
+++ b/src/TestStack.White/InputDevices/AttachedMouse.cs
@@ -14,17 +14,11 @@ namespace TestStack.White.InputDevices
         private readonly IActionListener actionListener;
         private readonly IMouse mouse;
 
-        #region Constructor
-
         internal AttachedMouse(IMouse mouse, IActionListener actionListener)
         {
             this.actionListener = actionListener;
             this.mouse = mouse;
         }
-
-        #endregion
-
-        #region Mouse Properties
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.Location"/>
@@ -43,10 +37,6 @@ namespace TestStack.White.InputDevices
             get { return mouse.Cursor; }
         }
 
-        #endregion
-
-        #region Click
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.Click(MouseButton)"/>
         /// </summary>
@@ -63,10 +53,6 @@ namespace TestStack.White.InputDevices
             mouse.Click(mouseButton, point, actionListener);
         }
 
-        #endregion
-
-        #region Double Click
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton)"/>
         /// </summary>
@@ -82,10 +68,6 @@ namespace TestStack.White.InputDevices
         {
             mouse.DoubleClick(mouseButton, point, actionListener);
         }
-
-        #endregion
-
-        #region Left Click
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.Click()"/>
@@ -122,10 +104,6 @@ namespace TestStack.White.InputDevices
         {
             mouse.LeftClick(point, actionListener);
         }
-
-        #endregion
-
-        #region Left Double Click
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.DoubleClick()"/>
@@ -165,10 +143,6 @@ namespace TestStack.White.InputDevices
             ActionPerformed();
         }
 
-        #endregion
-
-        #region Right Click
-        
         /// <summary>
         /// Implements <see cref="IBaseMouse.RightClick(Point)"/>
         /// </summary
@@ -185,10 +159,6 @@ namespace TestStack.White.InputDevices
         {
             mouse.RightClick(point, actionListener);
         }
-
-        #endregion 
-
-        #region Drag And Drop
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, IUIItem)"/>
@@ -226,10 +196,6 @@ namespace TestStack.White.InputDevices
             ActionPerformed();
         }
 
-        #endregion
-
-        #region Drag
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.DragHorizontally(IUIItem, int)"/>
         /// </summary
@@ -266,8 +232,6 @@ namespace TestStack.White.InputDevices
             ActionPerformed();
         }
 
-        #endregion
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.MoveOut()"/>
         /// </summary
@@ -286,13 +250,9 @@ namespace TestStack.White.InputDevices
             ActionPerformed();
         }
 
-        #region Protected
-
         protected virtual void ActionPerformed()
         {
             mouse.ActionPerformed(actionListener);
         }
-
-        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/AttachedMouse.cs
+++ b/src/TestStack.White/InputDevices/AttachedMouse.cs
@@ -8,62 +8,169 @@ namespace TestStack.White.InputDevices
     /// Any operation performed using the mouse would wait till the window is busy after this operation. Before any operation is 
     /// performed the window, from which it was retreived, is brought to focus if it is not.
     /// </summary>
-    public class AttachedMouse : IMouse
+    public class AttachedMouse : IBaseMouse
     {
         private readonly IActionListener actionListener;
-        private readonly Mouse mouse;
+        private readonly IMouse mouse;
 
+        #region Constructor
+
+        internal AttachedMouse(IMouse mouse, IActionListener actionListener)
+        {
+            this.actionListener = actionListener;
+            this.mouse = mouse;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Location"/>
+        /// </summary>
         public virtual Point Location
         {
             get { return mouse.Location; }
             set { mouse.Location = value; }
         }
 
-        internal AttachedMouse(Mouse mouse, IActionListener actionListener)
+        public MouseCursor Cursor
         {
-            this.actionListener = actionListener;
-            this.mouse = mouse;
+            get { return mouse.Cursor; }
         }
 
-        public virtual void RightClick()
-        {
-            mouse.RightClick();
-            ActionPerformed();
-        }
+        #region Mouse Click
 
-        public virtual void Click()
+        public void Click()
         {
             mouse.Click();
             ActionPerformed();
         }
 
-        public virtual void DoubleClick(Point point)
+        public void Click(Point point)
         {
-            mouse.DoubleClick(point);
+            mouse.Click(point, actionListener);
+        }
+
+        public void Click(MouseButton mouseButton)
+        {
+            mouse.Click(mouseButton, actionListener);
+        }
+
+        public void Click(MouseButton mouseButton, Point point)
+        {
+            mouse.Click(mouseButton, point, actionListener);
+        }
+
+        #endregion
+
+        #region Double Click
+
+        public void DoubleClick(Point point)
+        {
+            mouse.DoubleClick(point, actionListener);
+        }
+
+        public void DoubleClick(MouseButton mouseButton)
+        {
+            mouse.DoubleClick(mouseButton, actionListener);
+        }
+
+        public void DoubleClick(MouseButton mouseButton, Point point)
+        {
+            mouse.DoubleClick(mouseButton, point, actionListener);
+        }
+
+        #endregion
+
+        #region Right Click
+
+        public void RightClick()
+        {
+            mouse.RightClick();
             ActionPerformed();
         }
 
-        public virtual void Click(Point point)
+        public void RightClick(Point point)
         {
-            mouse.Click(point);
-            ActionPerformed();
+            mouse.RightClick(point, actionListener);
         }
 
-        public virtual void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
+        #endregion 
+
+        #region Drag And Drop
+
+        public void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
         {
             mouse.DragAndDrop(draggedItem, dropItem);
             ActionPerformed();
         }
 
-        public virtual void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
+        public void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem)
+        {
+            mouse.DragAndDrop(mouseButton, draggedItem, dropItem);
+            ActionPerformed();
+        }
+
+        public void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
         {
             mouse.DragAndDrop(draggedItem, startPosition, dropItem, endPosition);
             ActionPerformed();
         }
 
-        private void ActionPerformed()
+        public void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
         {
-            actionListener.ActionPerformed(Action.WindowMessage);
+            mouse.DragAndDrop(mouseButton,  draggedItem, startPosition, dropItem, endPosition);
+            ActionPerformed();
         }
+
+        #endregion
+
+        #region Drag
+
+        public void DragHorizontally(IUIItem uiItem, int distance)
+        {
+            mouse.DragHorizontally(uiItem, distance);
+            ActionPerformed();
+        }
+
+        public void DragHorizontally(MouseButton mouseButton, IUIItem uiItem, int distance)
+        {
+            mouse.DragHorizontally(mouseButton, uiItem, distance);
+            ActionPerformed();
+        }
+
+        public void DragVertically(IUIItem uiItem, int distance)
+        {
+            mouse.DragVertically(uiItem, distance);
+            ActionPerformed();
+        }
+
+        public void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance)
+        {
+            mouse.DragVertically(mouseButton, uiItem, distance);
+            ActionPerformed();
+        }
+
+        #endregion
+
+        public void MoveOut()
+        {
+            mouse.MoveOut();
+            ActionPerformed();
+        }
+
+        public void Move(Point position)
+        {
+            mouse.Move(position);
+            ActionPerformed();
+        }
+
+        #region Protected
+
+        protected void ActionPerformed()
+        {
+            mouse.ActionPerformed(actionListener);
+        }
+
+        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/BareMetalMouse.cs
+++ b/src/TestStack.White/InputDevices/BareMetalMouse.cs
@@ -4,84 +4,54 @@ using TestStack.White.WindowsAPI;
 
 namespace TestStack.White.InputDevices
 {
-    public class BareMetalMouse
+    public static class BareMetalMouse
     {
         #region DLL Import
 
         [DllImport("user32", EntryPoint = "SendInput")]
-        protected static extern int SendInput(uint numberOfInputs, ref Input input, int structSize);
+        private static extern int SendInput(uint numberOfInputs, ref Input input, int structSize);
 
         [DllImport("user32", EntryPoint = "SendInput")]
-        protected static extern int SendInput64(int numberOfInputs, ref Input64 input, int structSize);
+        private static extern int SendInput64(int numberOfInputs, ref Input64 input, int structSize);
 
         [DllImport("user32.dll")]
-        protected static extern IntPtr GetMessageExtraInfo();
+        private static extern IntPtr GetMessageExtraInfo();
 
         [DllImport("user32.dll")]
-        protected static extern bool GetCursorPos(ref System.Drawing.Point cursorInfo);
+        internal static extern bool GetCursorPos(ref System.Drawing.Point cursorInfo);
 
         [DllImport("user32.dll")]
-        protected static extern bool SetCursorPos(int x, int y);
+        internal static extern bool SetCursorPos(int x, int y);
 
         [DllImport("user32.dll")]
-        protected static extern bool GetCursorInfo(ref CursorInfo cursorInfo);
+        internal static extern bool GetCursorInfo(ref CursorInfo cursorInfo);
 
         [DllImport("user32.dll")]
-        protected static extern short GetDoubleClickTime();
+        internal static extern short GetDoubleClickTime();
 
         [DllImport("user32.dll")]
-        protected static extern int GetSystemMetrics(SystemMetric smIndex);
-
-        #endregion
-
-        #region Public
-
-        public static void LeftUp()
-        {
-            MouseButtonUp(MouseButton.Left);
-        }
-
-        public static void LeftDown()
-        {
-            MouseButtonDown(MouseButton.Left);
-        }
-
-        public static void RightUp()
-        {
-            MouseButtonUp(MouseButton.Right);
-        }
-
-        public static void RightDown()
-        {
-            MouseButtonDown(MouseButton.Right);
-        }
-
-        public static void MouseLeftButtonUpAndDown()
-        {
-            LeftDown();
-            LeftUp();
-        }
+        private static extern int GetSystemMetrics(SystemMetric smIndex);
 
         #endregion
 
         #region Private
 
-        protected static int RightMouseButtonDown
+        private static int RightMouseButtonDown
         {
             get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTDOWN : WindowsConstants.MOUSEEVENTF_LEFTDOWN; }
         }
 
-        protected static int RightMouseButtonUp
+        private static int RightMouseButtonUp
         {
             get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTUP : WindowsConstants.MOUSEEVENTF_LEFTUP; }
         }
 
-        protected static int LeftMouseButtonDown
+        private static int LeftMouseButtonDown
         {
             get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTDOWN : WindowsConstants.MOUSEEVENTF_RIGHTDOWN; }
         }
 
-        protected static int LeftMouseButtonUp
+        private static int LeftMouseButtonUp
         {
             get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTUP : WindowsConstants.MOUSEEVENTF_RIGHTUP; }
         }
@@ -89,7 +59,7 @@ namespace TestStack.White.InputDevices
         /// <summary>
         /// Performs a down / up sequence for the specified button
         /// </summary>
-        protected static void MouseButtonUpAndDown(MouseButton mouseButton)
+        internal static void MouseButtonUpAndDown(MouseButton mouseButton)
         {
             MouseButtonDown(mouseButton);
             MouseButtonUp(mouseButton);
@@ -98,7 +68,7 @@ namespace TestStack.White.InputDevices
         /// <summary>
         /// Performs a down for the specified button
         /// </summary>
-        protected static void MouseButtonDown(MouseButton mouseButton)
+        internal static void MouseButtonDown(MouseButton mouseButton)
         {
             SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, true)));
         }
@@ -106,7 +76,7 @@ namespace TestStack.White.InputDevices
         /// <summary>
         /// Performs an up for the specified button
         /// </summary>
-        protected static void MouseButtonUp(MouseButton mouseButton)
+        internal static void MouseButtonUp(MouseButton mouseButton)
         {
             SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, false)));
         }
@@ -116,7 +86,7 @@ namespace TestStack.White.InputDevices
         /// </summary>
         /// <param name="mouseButton">The button to get the input for</param>
         /// <param name="isDown">Flag if down is wanted, up otherwise</param>
-        protected static MouseInput GetInputForButton(MouseButton mouseButton, bool isDown)
+        private static MouseInput GetInputForButton(MouseButton mouseButton, bool isDown)
         {
             switch (mouseButton)
             {
@@ -135,7 +105,7 @@ namespace TestStack.White.InputDevices
             }
         }
 
-        protected static void SendInput(Input input)
+        private static void SendInput(Input input)
         {
             // Added check for 32/64 bit  
             if (IntPtr.Size == 4)
@@ -147,7 +117,7 @@ namespace TestStack.White.InputDevices
             }
         }
 
-        protected static MouseInput MouseInput(int command, int mouseData = 0)
+        private static MouseInput MouseInput(int command, int mouseData = 0)
         {
             return new MouseInput(command, GetMessageExtraInfo(), mouseData);
         }

--- a/src/TestStack.White/InputDevices/BareMetalMouse.cs
+++ b/src/TestStack.White/InputDevices/BareMetalMouse.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Runtime.InteropServices;
+using TestStack.White.WindowsAPI;
+
+namespace TestStack.White.InputDevices
+{
+    public class BareMetalMouse
+    {
+        #region DLL Import
+
+        [DllImport("user32", EntryPoint = "SendInput")]
+        protected static extern int SendInput(uint numberOfInputs, ref Input input, int structSize);
+
+        [DllImport("user32", EntryPoint = "SendInput")]
+        protected static extern int SendInput64(int numberOfInputs, ref Input64 input, int structSize);
+
+        [DllImport("user32.dll")]
+        protected static extern IntPtr GetMessageExtraInfo();
+
+        [DllImport("user32.dll")]
+        protected static extern bool GetCursorPos(ref System.Drawing.Point cursorInfo);
+
+        [DllImport("user32.dll")]
+        protected static extern bool SetCursorPos(int x, int y);
+
+        [DllImport("user32.dll")]
+        protected static extern bool GetCursorInfo(ref CursorInfo cursorInfo);
+
+        [DllImport("user32.dll")]
+        protected static extern short GetDoubleClickTime();
+
+        [DllImport("user32.dll")]
+        protected static extern int GetSystemMetrics(SystemMetric smIndex);
+
+        #endregion
+
+        #region Public
+
+        public static void LeftUp()
+        {
+            MouseButtonUp(MouseButton.Left);
+        }
+
+        public static void LeftDown()
+        {
+            MouseButtonDown(MouseButton.Left);
+        }
+
+        public static void RightUp()
+        {
+            MouseButtonUp(MouseButton.Right);
+        }
+
+        public static void RightDown()
+        {
+            MouseButtonDown(MouseButton.Right);
+        }
+
+        public static void MouseLeftButtonUpAndDown()
+        {
+            LeftDown();
+            LeftUp();
+        }
+
+        #endregion
+
+        #region Private
+
+        protected static int RightMouseButtonDown
+        {
+            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTDOWN : WindowsConstants.MOUSEEVENTF_LEFTDOWN; }
+        }
+
+        protected static int RightMouseButtonUp
+        {
+            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTUP : WindowsConstants.MOUSEEVENTF_LEFTUP; }
+        }
+
+        protected static int LeftMouseButtonDown
+        {
+            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTDOWN : WindowsConstants.MOUSEEVENTF_RIGHTDOWN; }
+        }
+
+        protected static int LeftMouseButtonUp
+        {
+            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTUP : WindowsConstants.MOUSEEVENTF_RIGHTUP; }
+        }
+
+        /// <summary>
+        /// Performs a down / up sequence for the specified button
+        /// </summary>
+        protected static void MouseButtonUpAndDown(MouseButton mouseButton)
+        {
+            MouseButtonDown(mouseButton);
+            MouseButtonUp(mouseButton);
+        }
+
+        /// <summary>
+        /// Performs a down for the specified button
+        /// </summary>
+        protected static void MouseButtonDown(MouseButton mouseButton)
+        {
+            SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, true)));
+        }
+
+        /// <summary>
+        /// Performs an up for the specified button
+        /// </summary>
+        protected static void MouseButtonUp(MouseButton mouseButton)
+        {
+            SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, false)));
+        }
+
+        /// <summary>
+        /// Generates the input object for the button
+        /// </summary>
+        /// <param name="mouseButton">The button to get the input for</param>
+        /// <param name="isDown">Flag if down is wanted, up otherwise</param>
+        protected static MouseInput GetInputForButton(MouseButton mouseButton, bool isDown)
+        {
+            switch (mouseButton)
+            {
+                case MouseButton.Left:
+                    return MouseInput(isDown ? LeftMouseButtonDown : LeftMouseButtonUp);
+                case MouseButton.Right:
+                    return MouseInput(isDown ? RightMouseButtonDown : RightMouseButtonUp);
+                case MouseButton.Middle:
+                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_MIDDLEDOWN : WindowsConstants.MOUSEEVENTF_MIDDLEUP);
+                case MouseButton.XButton1:
+                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_XDOWN : WindowsConstants.MOUSEEVENTF_XUP, 0x0001);
+                case MouseButton.XButton2:
+                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_XDOWN : WindowsConstants.MOUSEEVENTF_XUP, 0x0002);
+                default:
+                    throw new ArgumentOutOfRangeException("mouseButton", "Unknown mouse button");
+            }
+        }
+
+        protected static void SendInput(Input input)
+        {
+            // Added check for 32/64 bit  
+            if (IntPtr.Size == 4)
+                SendInput(1, ref input, Marshal.SizeOf(typeof(Input)));
+            else
+            {
+                var input64 = new Input64(input);
+                SendInput64(1, ref input64, Marshal.SizeOf(typeof(Input)));
+            }
+        }
+
+        protected static MouseInput MouseInput(int command, int mouseData = 0)
+        {
+            return new MouseInput(command, GetMessageExtraInfo(), mouseData);
+        }
+
+        #endregion
+    }
+}

--- a/src/TestStack.White/InputDevices/BareMetalMouse.cs
+++ b/src/TestStack.White/InputDevices/BareMetalMouse.cs
@@ -6,8 +6,6 @@ namespace TestStack.White.InputDevices
 {
     public static class BareMetalMouse
     {
-        #region DLL Import
-
         [DllImport("user32", EntryPoint = "SendInput")]
         private static extern int SendInput(uint numberOfInputs, ref Input input, int structSize);
 
@@ -31,10 +29,6 @@ namespace TestStack.White.InputDevices
 
         [DllImport("user32.dll")]
         private static extern int GetSystemMetrics(SystemMetric smIndex);
-
-        #endregion
-
-        #region Private
 
         private static int RightMouseButtonDown
         {
@@ -121,7 +115,5 @@ namespace TestStack.White.InputDevices
         {
             return new MouseInput(command, GetMessageExtraInfo(), mouseData);
         }
-
-        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/BaseMouse.cs
+++ b/src/TestStack.White/InputDevices/BaseMouse.cs
@@ -78,23 +78,7 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Mouse Click
-
-        /// <summary>
-        /// Implements <see cref="IBaseMouse.Click()"/>
-        /// </summary>
-        public virtual void Click()
-        {
-            Click(MouseButton.Left);
-        }
-
-        /// <summary>
-        /// Implements <see cref="IBaseMouse.Click(Point)"/>
-        /// </summary>
-        public virtual void Click(Point point)
-        {
-            Click(MouseButton.Left, point);
-        }
-
+        
         /// <summary>
         /// Implements <see cref="IBaseMouse.Click(MouseButton)"/>
         /// </summary>
@@ -131,15 +115,7 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Double Click
-
-        /// <summary>
-        /// Implements <see cref="IBaseMouse.DoubleClick(Point)"/>
-        /// </summary>
-        public virtual void DoubleClick(Point point)
-        {
-            DoubleClick(MouseButton.Left, point);
-        }
-
+        
         /// <summary>
         /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton)"/>
         /// </summary>
@@ -157,6 +133,83 @@ namespace TestStack.White.InputDevices
         {
             Move(point);
             DoubleClick(mouseButton);
+        }
+
+        #endregion
+
+        #region Mouse Left Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click()"/>
+        /// </summary>
+        [Obsolete("Use LeftClick instead")]
+        public virtual void Click()
+        {
+            Click(MouseButton.Left);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(Point)"/>
+        /// </summary>
+        [Obsolete("Use LeftClick instead")]
+        public virtual void Click(Point point)
+        {
+            Click(MouseButton.Left, point);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftClick()"/>
+        /// </summary>
+        public virtual void LeftClick()
+        {
+            Click(MouseButton.Left);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftClick(Point)"/>
+        /// </summary>
+        public virtual void LeftClick(Point point)
+        {
+            Click(MouseButton.Left, point);
+        }
+        
+        #endregion
+
+        #region Mouse Left Double Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick()"/>
+        /// </summary>
+        [Obsolete("Use LeftDoubleClick instead")]
+        public virtual void DoubleClick()
+        {
+            DoubleClick(MouseButton.Left);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(Point)"/>
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        [Obsolete("Use LeftDoubleClick instead")]
+        public virtual void DoubleClick(Point point)
+        {
+            DoubleClick(MouseButton.Left, point);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftDoubleClick()"/>
+        /// </summary>
+        public virtual void LeftDoubleClick()
+        {
+            DoubleClick(MouseButton.Left);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.LeftDoubleClick(Point)"/>
+        /// </summary>
+        public virtual void LeftDoubleClick(Point point)
+        {
+            DoubleClick(MouseButton.Left, point);
         }
 
         #endregion

--- a/src/TestStack.White/InputDevices/BaseMouse.cs
+++ b/src/TestStack.White/InputDevices/BaseMouse.cs
@@ -14,16 +14,10 @@ namespace TestStack.White.InputDevices
 {
     public abstract class BaseMouse : IBaseMouse
     {
-        #region Fields
-
         protected readonly Dictionary<MouseButton, DateTime> LastClickTimes;
         protected readonly Dictionary<MouseButton, Point> LastClickLocations;
         protected readonly short DoubleClickTime = BareMetalMouse.GetDoubleClickTime();
         protected const int ExtraMillisecondsBecauseOfBugInWindows = 13;
-
-        #endregion
-
-        #region Constructor
 
         protected BaseMouse()
         {
@@ -35,10 +29,6 @@ namespace TestStack.White.InputDevices
                 LastClickLocations.Add(mouseButton, new Point(0, 0));
             }
         }
-
-        #endregion
-
-        #region Mouse Properties
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.Location"/>
@@ -75,10 +65,6 @@ namespace TestStack.White.InputDevices
             }
         }
 
-        #endregion
-
-        #region Mouse Click
-        
         /// <summary>
         /// Implements <see cref="IBaseMouse.Click(MouseButton)"/>
         /// </summary>
@@ -112,10 +98,6 @@ namespace TestStack.White.InputDevices
             Click(mouseButton);
         }
 
-        #endregion
-
-        #region Double Click
-        
         /// <summary>
         /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton)"/>
         /// </summary>
@@ -134,10 +116,6 @@ namespace TestStack.White.InputDevices
             Move(point);
             DoubleClick(mouseButton);
         }
-
-        #endregion
-
-        #region Mouse Left Click
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.Click()"/>
@@ -173,10 +151,6 @@ namespace TestStack.White.InputDevices
             Click(MouseButton.Left, point);
         }
         
-        #endregion
-
-        #region Mouse Left Double Click
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.DoubleClick()"/>
         /// </summary>
@@ -212,10 +186,6 @@ namespace TestStack.White.InputDevices
             DoubleClick(MouseButton.Left, point);
         }
 
-        #endregion
-
-        #region Right Click
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.RightClick()"/>
         /// </summary>
@@ -231,10 +201,6 @@ namespace TestStack.White.InputDevices
         {
             Click(MouseButton.Right, point);
         }
-
-        #endregion
-
-        #region Drag And Drop
 
         /// <summary>
         /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, IUIItem)"/>
@@ -281,10 +247,6 @@ namespace TestStack.White.InputDevices
             dropItem.ActionPerformed(Action.WindowMessage);
         }
 
-        #endregion
-
-        #region Drag
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.DragHorizontally(IUIItem, int)"/>
         /// </summary>
@@ -329,10 +291,6 @@ namespace TestStack.White.InputDevices
             BareMetalMouse.MouseButtonUp(mouseButton);
         }
 
-        #endregion
-
-        #region Move
-
         /// <summary>
         /// Implements <see cref="IBaseMouse.MoveOut()"/>
         /// </summary>
@@ -349,12 +307,6 @@ namespace TestStack.White.InputDevices
             Location = position;
         }
 
-        #endregion
-
-        #region Public
-
         public abstract void ActionPerformed(IActionListener actionListener);
-
-        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/BaseMouse.cs
+++ b/src/TestStack.White/InputDevices/BaseMouse.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Windows;
+using TestStack.White.Configuration;
+using TestStack.White.Drawing;
+using TestStack.White.UIA;
+using TestStack.White.UIItems;
+using TestStack.White.UIItems.Actions;
+using TestStack.White.WindowsAPI;
+using Action = TestStack.White.UIItems.Actions.Action;
+
+namespace TestStack.White.InputDevices
+{
+    public abstract class BaseMouse : BareMetalMouse, IBaseMouse
+    {
+        #region Fields
+
+        protected readonly Dictionary<MouseButton, DateTime> LastClickTimes;
+        protected readonly Dictionary<MouseButton, Point> LastClickLocations;
+        protected readonly short DoubleClickTime = GetDoubleClickTime();
+        protected const int ExtraMillisecondsBecauseOfBugInWindows = 13;
+
+        #endregion
+
+        #region Constructor
+
+        protected BaseMouse()
+        {
+            LastClickTimes = new Dictionary<MouseButton, DateTime>();
+            LastClickLocations = new Dictionary<MouseButton, Point>();
+            foreach (MouseButton mouseButton in Enum.GetValues(typeof(MouseButton)))
+            {
+                LastClickTimes.Add(mouseButton, DateTime.Now);
+                LastClickLocations.Add(mouseButton, new Point(0, 0));
+            }
+        }
+
+        #endregion
+
+        #region Mouse Properties
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Location"/>
+        /// </summary>
+        public virtual Point Location
+        {
+            get
+            {
+                var point = new System.Drawing.Point();
+                GetCursorPos(ref point);
+                return point.ConvertToWindowsPoint();
+            }
+            set
+            {
+                if (value.IsInvalid())
+                {
+                    throw new WhiteException(string.Format("Trying to set location outside the screen. {0}", value));
+                }
+                SetCursorPos((int)value.X, (int)value.Y);
+            }
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Cursor"/>
+        /// </summary>
+        public virtual MouseCursor Cursor
+        {
+            get
+            {
+                var cursorInfo = CursorInfo.New();
+                GetCursorInfo(ref cursorInfo);
+                var i = cursorInfo.handle.ToInt32();
+                return new MouseCursor(i);
+            }
+        }
+
+        #endregion
+
+        #region Mouse Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click()"/>
+        /// </summary>
+        public virtual void Click()
+        {
+            Click(MouseButton.Left);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(Point)"/>
+        /// </summary>
+        public virtual void Click(Point point)
+        {
+            Click(MouseButton.Left, point);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(MouseButton)"/>
+        /// </summary>
+        public virtual void Click(MouseButton mouseButton)
+        {
+            var currentClickLocation = Location;
+            // Check if the location is the same as with last click
+            if (LastClickLocations[mouseButton].Equals(currentClickLocation))
+            {
+                // Get the timeout needed to not fire a double click
+                var timeout = DoubleClickTime - DateTime.Now.Subtract(LastClickTimes[mouseButton]).Milliseconds;
+                // Wait the needed time to prevent the double click
+                if (timeout > 0)
+                {
+                    Thread.Sleep(timeout + ExtraMillisecondsBecauseOfBugInWindows);
+                }
+            }
+            // Perform the click
+            MouseButtonUpAndDown(mouseButton);
+            // Update the time and location
+            LastClickTimes[mouseButton] = DateTime.Now;
+            LastClickLocations[mouseButton] = Location;
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Click(MouseButton, Point)"/>
+        /// </summary>
+        public virtual void Click(MouseButton mouseButton, Point point)
+        {
+            Move(point);
+            Click(mouseButton);
+        }
+
+        #endregion
+
+        #region Double Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(Point)"/>
+        /// </summary>
+        public virtual void DoubleClick(Point point)
+        {
+            DoubleClick(MouseButton.Left, point);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton)"/>
+        /// </summary>
+        public virtual void DoubleClick(MouseButton mouseButton)
+        {
+            MouseButtonUpAndDown(mouseButton);
+            Thread.Sleep(CoreAppXmlConfiguration.Instance.DoubleClickInterval);
+            MouseButtonUpAndDown(mouseButton);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DoubleClick(MouseButton, Point)"/>
+        /// </summary>
+        public virtual void DoubleClick(MouseButton mouseButton, Point point)
+        {
+            Move(point);
+            DoubleClick(mouseButton);
+        }
+
+        #endregion
+
+        #region Right Click
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.RightClick()"/>
+        /// </summary>
+        public virtual void RightClick()
+        {
+            Click(MouseButton.Right);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.RightClick(Point)"/>
+        /// </summary>
+        public virtual void RightClick(Point point)
+        {
+            Click(MouseButton.Right, point);
+        }
+
+        #endregion
+
+        #region Drag And Drop
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, IUIItem)"/>
+        /// </summary>
+        public virtual void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
+        {
+            DragAndDrop(MouseButton.Left, draggedItem, dropItem);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(MouseButton, IUIItem, IUIItem)"/>
+        /// </summary>
+        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem)
+        {
+            var startPosition = draggedItem.Bounds.Center();
+            var endPosition = dropItem.Bounds.Center();
+            DragAndDrop(mouseButton, draggedItem, startPosition, dropItem, endPosition);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(IUIItem, Point, IUIItem, Point)"/>
+        /// </summary>
+        public virtual void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
+        {
+            DragAndDrop(MouseButton.Left, draggedItem, startPosition, dropItem, endPosition);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragAndDrop(MouseButton, IUIItem, Point, IUIItem, Point)"/>
+        /// </summary>
+        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
+        {
+            Move(startPosition);
+            MouseButtonDown(mouseButton);
+            var dragStepFraction = (float)(1.0 / CoreAppXmlConfiguration.Instance.DragStepCount);
+            for (var i = 1; i <= CoreAppXmlConfiguration.Instance.DragStepCount; i++)
+            {
+                var newX = startPosition.X + (endPosition.X - startPosition.X) * (dragStepFraction * i);
+                var newY = startPosition.Y + (endPosition.Y - startPosition.Y) * (dragStepFraction * i);
+                var newPoint = new Point((int)newX, (int)newY);
+                Move(newPoint);
+            }
+            MouseButtonUp(mouseButton);
+            dropItem.ActionPerformed(Action.WindowMessage);
+        }
+
+        #endregion
+
+        #region Drag
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragHorizontally(IUIItem, int)"/>
+        /// </summary>
+        public virtual void DragHorizontally(IUIItem uiItem, int distance)
+        {
+            DragHorizontally(MouseButton.Left, uiItem, distance);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragHorizontally(MouseButton, IUIItem, int)"/>
+        /// </summary>
+        public virtual void DragHorizontally(MouseButton mouseButton, IUIItem uiItem, int distance)
+        {
+            Location = uiItem.Bounds.Center();
+            var currentXLocation = Location.X;
+            var currentYLocation = Location.Y;
+            MouseButtonDown(mouseButton);
+            ActionPerformed(uiItem);
+            Move(new Point(currentXLocation + distance, currentYLocation));
+            MouseButtonUp(mouseButton);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragVertically(IUIItem, int)"/>
+        /// </summary>
+        public virtual void DragVertically(IUIItem uiItem, int distance)
+        {
+            DragVertically(MouseButton.Left, uiItem, distance);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.DragVertically(MouseButton, IUIItem, int)"/>
+        /// </summary>
+        public virtual void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance)
+        {
+            Move(uiItem.Bounds.Center());
+            var currentXLocation = Location.X;
+            var currentYLocation = Location.Y;
+            MouseButtonDown(mouseButton);
+            ActionPerformed(uiItem);
+            Move(new Point(currentXLocation, currentYLocation + distance));
+            MouseButtonUp(mouseButton);
+        }
+
+        #endregion
+
+        #region Move
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.MoveOut()"/>
+        /// </summary>
+        public virtual void MoveOut()
+        {
+            Move(new Point(0, 0));
+        }
+
+        /// <summary>
+        /// Implements <see cref="IBaseMouse.Move(Point)"/>
+        /// </summary>
+        public virtual void Move(Point position)
+        {
+            Location = position;
+        }
+
+        #endregion
+
+        #region Public
+
+        public abstract void ActionPerformed(IActionListener actionListener);
+
+        #endregion
+    }
+}

--- a/src/TestStack.White/InputDevices/BaseMouse.cs
+++ b/src/TestStack.White/InputDevices/BaseMouse.cs
@@ -12,13 +12,13 @@ using Action = TestStack.White.UIItems.Actions.Action;
 
 namespace TestStack.White.InputDevices
 {
-    public abstract class BaseMouse : BareMetalMouse, IBaseMouse
+    public abstract class BaseMouse : IBaseMouse
     {
         #region Fields
 
         protected readonly Dictionary<MouseButton, DateTime> LastClickTimes;
         protected readonly Dictionary<MouseButton, Point> LastClickLocations;
-        protected readonly short DoubleClickTime = GetDoubleClickTime();
+        protected readonly short DoubleClickTime = BareMetalMouse.GetDoubleClickTime();
         protected const int ExtraMillisecondsBecauseOfBugInWindows = 13;
 
         #endregion
@@ -48,7 +48,7 @@ namespace TestStack.White.InputDevices
             get
             {
                 var point = new System.Drawing.Point();
-                GetCursorPos(ref point);
+                BareMetalMouse.GetCursorPos(ref point);
                 return point.ConvertToWindowsPoint();
             }
             set
@@ -57,7 +57,7 @@ namespace TestStack.White.InputDevices
                 {
                     throw new WhiteException(string.Format("Trying to set location outside the screen. {0}", value));
                 }
-                SetCursorPos((int)value.X, (int)value.Y);
+                BareMetalMouse.SetCursorPos((int)value.X, (int)value.Y);
             }
         }
 
@@ -69,7 +69,7 @@ namespace TestStack.White.InputDevices
             get
             {
                 var cursorInfo = CursorInfo.New();
-                GetCursorInfo(ref cursorInfo);
+                BareMetalMouse.GetCursorInfo(ref cursorInfo);
                 var i = cursorInfo.handle.ToInt32();
                 return new MouseCursor(i);
             }
@@ -97,7 +97,7 @@ namespace TestStack.White.InputDevices
                 }
             }
             // Perform the click
-            MouseButtonUpAndDown(mouseButton);
+            BareMetalMouse.MouseButtonUpAndDown(mouseButton);
             // Update the time and location
             LastClickTimes[mouseButton] = DateTime.Now;
             LastClickLocations[mouseButton] = Location;
@@ -121,9 +121,9 @@ namespace TestStack.White.InputDevices
         /// </summary>
         public virtual void DoubleClick(MouseButton mouseButton)
         {
-            MouseButtonUpAndDown(mouseButton);
+            BareMetalMouse.MouseButtonUpAndDown(mouseButton);
             Thread.Sleep(CoreAppXmlConfiguration.Instance.DoubleClickInterval);
-            MouseButtonUpAndDown(mouseButton);
+            BareMetalMouse.MouseButtonUpAndDown(mouseButton);
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace TestStack.White.InputDevices
         public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
         {
             Move(startPosition);
-            MouseButtonDown(mouseButton);
+            BareMetalMouse.MouseButtonDown(mouseButton);
             var dragStepFraction = (float)(1.0 / CoreAppXmlConfiguration.Instance.DragStepCount);
             for (var i = 1; i <= CoreAppXmlConfiguration.Instance.DragStepCount; i++)
             {
@@ -277,7 +277,7 @@ namespace TestStack.White.InputDevices
                 var newPoint = new Point((int)newX, (int)newY);
                 Move(newPoint);
             }
-            MouseButtonUp(mouseButton);
+            BareMetalMouse.MouseButtonUp(mouseButton);
             dropItem.ActionPerformed(Action.WindowMessage);
         }
 
@@ -301,10 +301,10 @@ namespace TestStack.White.InputDevices
             Location = uiItem.Bounds.Center();
             var currentXLocation = Location.X;
             var currentYLocation = Location.Y;
-            MouseButtonDown(mouseButton);
+            BareMetalMouse.MouseButtonDown(mouseButton);
             ActionPerformed(uiItem);
             Move(new Point(currentXLocation + distance, currentYLocation));
-            MouseButtonUp(mouseButton);
+            BareMetalMouse.MouseButtonUp(mouseButton);
         }
 
         /// <summary>
@@ -323,10 +323,10 @@ namespace TestStack.White.InputDevices
             Move(uiItem.Bounds.Center());
             var currentXLocation = Location.X;
             var currentYLocation = Location.Y;
-            MouseButtonDown(mouseButton);
+            BareMetalMouse.MouseButtonDown(mouseButton);
             ActionPerformed(uiItem);
             Move(new Point(currentXLocation, currentYLocation + distance));
-            MouseButtonUp(mouseButton);
+            BareMetalMouse.MouseButtonUp(mouseButton);
         }
 
         #endregion

--- a/src/TestStack.White/InputDevices/IBaseMouse.cs
+++ b/src/TestStack.White/InputDevices/IBaseMouse.cs
@@ -6,8 +6,6 @@ namespace TestStack.White.InputDevices
 {
     public interface IBaseMouse
     {
-        #region Mouse Properties
-
         /// <summary>
         /// Location <see cref="Point"/> of Mouse
         /// </summary>
@@ -18,10 +16,6 @@ namespace TestStack.White.InputDevices
         /// </summary>
         MouseCursor Cursor { get; }
 
-        #endregion
-
-        #region Mouse Click
-        
         /// <summary>
         /// Perform a Click Operation
         /// </summary>
@@ -43,10 +37,6 @@ namespace TestStack.White.InputDevices
         /// </remarks>
         void Click(MouseButton mouseButton, Point point);
 
-        #endregion
-
-        #region Double Click
-
         /// <summary>
         /// Perform a Double Click Operation
         /// </summary>
@@ -59,10 +49,6 @@ namespace TestStack.White.InputDevices
         /// <param name="mouseButton">MouseButton to double click</param>
         /// <param name="point">Point where to Double Click on</param>
         void DoubleClick(MouseButton mouseButton, Point point);
-
-        #endregion
-
-        #region Mouse Left Click
 
         /// <summary>
         /// Perform a Left Click Operation
@@ -88,10 +74,6 @@ namespace TestStack.White.InputDevices
         /// <param name="point">Point where to Click on</param>
         void LeftClick(Point point);
 
-        #endregion
-
-        #region Mouse Left Double Click
-
         /// <summary>
         /// Perform a Mouse Left Double Click Operation
         /// </summary>
@@ -116,10 +98,6 @@ namespace TestStack.White.InputDevices
         /// <param name="point">Point where to Double Click on</param>
         void LeftDoubleClick(Point point);
 
-        #endregion
-
-        #region Right Click
-
         /// <summary>
         /// Perform a Right Click Operation
         /// </summary>
@@ -130,10 +108,6 @@ namespace TestStack.White.InputDevices
         /// </summary>
         /// <param name="point">Point where to Double Click on</param>
         void RightClick(Point point);
-
-        #endregion
-
-        #region Drag And Drop
 
         /// <summary>
         /// Drags the dragged <see cref="IUIItem"/> and drops it on the drop <see cref="IUIItem"/>. 
@@ -190,10 +164,6 @@ namespace TestStack.White.InputDevices
         void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem,
             Point endPosition);
 
-        #endregion
-
-        #region Drag
-
         /// <summary>
         /// Drag an <see cref="IUIItem"/> horizontally a specific distance
         /// </summary>
@@ -224,10 +194,6 @@ namespace TestStack.White.InputDevices
         /// <param name="distance">Distance to drag</param>
         void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance);
 
-        #endregion
-
-        #region Move
-
         /// <summary>
         /// Move the Mouse Cursor to Point 0, 0
         /// </summary>
@@ -238,7 +204,5 @@ namespace TestStack.White.InputDevices
         /// </summary>
         /// <param name="position"><see cref="Point"/> where to position the Mouse Cursor to</param>
         void Move(Point position);
-
-        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/IBaseMouse.cs
+++ b/src/TestStack.White/InputDevices/IBaseMouse.cs
@@ -1,0 +1,204 @@
+using System.Windows;
+using TestStack.White.UIItems;
+
+namespace TestStack.White.InputDevices
+{
+    public interface IBaseMouse
+    {
+        #region Mouse Properties
+
+        /// <summary>
+        /// Location <see cref="Point"/> of Mouse
+        /// </summary>
+        Point Location { get; set; }
+
+        /// <summary>
+        /// <see cref="MouseCursor"/> Cursor of the Mouse
+        /// </summary>
+        MouseCursor Cursor { get; }
+
+        #endregion
+
+        #region Mouse Click
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        void Click();
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        void Click(Point point);
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to Click</param>
+        /// <remarks>
+        /// Clicks the specified mouse button. Makes sure to not accidentaly fire a double click
+        /// if called multiple times
+        /// </remarks>
+        void Click(MouseButton mouseButton);
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to Click</param>
+        /// <param name="point">Point to Click on</param>
+        /// <remarks>
+        /// Clicks the specified mouse button. Makes sure to not accidentaly fire a double click
+        /// if called multiple times
+        /// </remarks>
+        void Click(MouseButton mouseButton, Point point);
+
+        #endregion
+
+        #region Double Click
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        void DoubleClick(Point point);
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to double click</param>
+        void DoubleClick(MouseButton mouseButton);
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to double click</param>
+        /// <param name="point">Point where to Double Click on</param>
+        void DoubleClick(MouseButton mouseButton, Point point);
+
+        #endregion
+
+        #region Right Click
+
+        /// <summary>
+        /// Perform a Right Click Operation
+        /// </summary>
+        void RightClick();
+
+        /// <summary>
+        /// Perform a Right Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        void RightClick(Point point);
+
+        #endregion
+
+        #region Drag And Drop
+
+        /// <summary>
+        /// Drags the dragged <see cref="IUIItem"/> and drops it on the drop <see cref="IUIItem"/>. 
+        /// This can be used for any two UIItems  whether they are same application or different. 
+        /// To drop items on desktop use Desktop class's Drop method. 
+        /// White starts and ends the drag from center of the UIItems.
+        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
+        /// This can be set but configuring DragStepCount property. This is by default set to 1.
+        /// </summary>
+        /// <param name="draggedItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="dropItem"><see cref="IUIItem"/> to drop on</param>
+        void DragAndDrop(IUIItem draggedItem, IUIItem dropItem);
+
+        /// <summary>
+        /// Drags the dragged <see cref="IUIItem"/> and drops it on the drop <see cref="IUIItem"/>. 
+        /// This can be used for any two UIItems  whether they are same application or different. 
+        /// To drop items on desktop use Desktop class's Drop method. 
+        /// White starts and ends the drag from center of the UIItems.
+        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
+        /// This can be set but configuring DragStepCount property. This is by default set to 1.
+        /// </summary>
+        /// <param name="mouseButton"><see cref="MouseButton"/> to use for dragging</param>
+        /// <param name="draggedItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="dropItem"><see cref="IUIItem"/> to drop on</param>
+        void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem);
+
+        /// <summary>
+        /// Drags the dragged <see cref="IUIItem"/> and drops it on the drop <see cref="IUIItem"/>. 
+        /// This can be used for any two UIItems  whether they are same application or different. 
+        /// To drop items on desktop use Desktop class's Drop method. 
+        /// White starts and ends the drag from center of the UIItems.
+        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
+        /// This can be set but configuring DragStepCount property. This is by default set to 1.
+        /// </summary>
+        /// <param name="draggedItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="startPosition">Start Position <see cref="Point"/></param>
+        /// <param name="dropItem"><see cref="IUIItem"/> to drop on</param>
+        /// <param name="endPosition">End Position <see cref="Point"/></param>
+        void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition);
+
+        /// <summary>
+        /// Drags the dragged <see cref="IUIItem"/> and drops it on the drop <see cref="IUIItem"/>. 
+        /// This can be used for any two UIItems  whether they are same application or different. 
+        /// To drop items on desktop use Desktop class's Drop method. 
+        /// White starts and ends the drag from center of the UIItems.
+        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
+        /// This can be set but configuring DragStepCount property. This is by default set to 1.
+        /// </summary>
+        /// <param name="mouseButton"><see cref="MouseButton"/> to use for dragging</param>
+        /// <param name="draggedItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="startPosition">Start Position <see cref="Point"/></param>
+        /// <param name="dropItem"><see cref="IUIItem"/> to drop on</param>
+        /// <param name="endPosition">End Position <see cref="Point"/></param>
+        void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem,
+            Point endPosition);
+
+        #endregion
+
+        #region Drag
+
+        /// <summary>
+        /// Drag an <see cref="IUIItem"/> horizontally a specific distance
+        /// </summary>
+        /// <param name="uiItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="distance">Distance to drag</param>
+        void DragHorizontally(IUIItem uiItem, int distance);
+
+        /// <summary>
+        /// Drag an <see cref="IUIItem"/> horizontally a specific distance
+        /// </summary>
+        /// <param name="mouseButton"><see cref="MouseButton"/> to use for dragging</param>
+        /// <param name="uiItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="distance">Distance to drag</param>
+        void DragHorizontally(MouseButton mouseButton, IUIItem uiItem, int distance);
+
+        /// <summary>
+        /// Drag an <see cref="IUIItem"/> vertically a specific distance
+        /// </summary>
+        /// <param name="uiItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="distance">Distance to drag</param>
+        void DragVertically(IUIItem uiItem, int distance);
+
+        /// <summary>
+        /// Drag an <see cref="IUIItem"/> vertically a specific distance
+        /// </summary>
+        /// <param name="mouseButton"><see cref="MouseButton"/> to use for dragging</param>
+        /// <param name="uiItem"><see cref="IUIItem"/> to drag</param>
+        /// <param name="distance">Distance to drag</param>
+        void DragVertically(MouseButton mouseButton, IUIItem uiItem, int distance);
+
+        #endregion
+
+        #region Move
+
+        /// <summary>
+        /// Move the Mouse Cursor to Point 0, 0
+        /// </summary>
+        void MoveOut();
+
+        /// <summary>
+        /// Move the Mouse Cursor to a certain <see cref="Point"/>
+        /// </summary>
+        /// <param name="position"><see cref="Point"/> where to position the Mouse Cursor to</param>
+        void Move(Point position);
+
+        #endregion
+    }
+}

--- a/src/TestStack.White/InputDevices/IBaseMouse.cs
+++ b/src/TestStack.White/InputDevices/IBaseMouse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using TestStack.White.UIItems;
 
@@ -20,18 +21,7 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Mouse Click
-
-        /// <summary>
-        /// Perform a Click Operation
-        /// </summary>
-        void Click();
-
-        /// <summary>
-        /// Perform a Click Operation
-        /// </summary>
-        /// <param name="point">Point where to Click on</param>
-        void Click(Point point);
-
+        
         /// <summary>
         /// Perform a Click Operation
         /// </summary>
@@ -60,12 +50,6 @@ namespace TestStack.White.InputDevices
         /// <summary>
         /// Perform a Double Click Operation
         /// </summary>
-        /// <param name="point">Point where to Double Click on</param>
-        void DoubleClick(Point point);
-
-        /// <summary>
-        /// Perform a Double Click Operation
-        /// </summary>
         /// <param name="mouseButton">MouseButton to double click</param>
         void DoubleClick(MouseButton mouseButton);
 
@@ -75,6 +59,62 @@ namespace TestStack.White.InputDevices
         /// <param name="mouseButton">MouseButton to double click</param>
         /// <param name="point">Point where to Double Click on</param>
         void DoubleClick(MouseButton mouseButton, Point point);
+
+        #endregion
+
+        #region Mouse Left Click
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        [Obsolete("Use LeftClick instead")]
+        void Click();
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        [Obsolete("Use LeftClick instead")]
+        void Click(Point point);
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        void LeftClick();
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        void LeftClick(Point point);
+
+        #endregion
+
+        #region Mouse Left Double Click
+
+        /// <summary>
+        /// Perform a Mouse Left Double Click Operation
+        /// </summary>
+        [Obsolete("Use LeftDoubleClick instead")]
+        void DoubleClick();
+
+        /// <summary>
+        /// Perform a Mouse Left Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        [Obsolete("Use LeftDoubleClick instead")]
+        void DoubleClick(Point point);
+
+        /// <summary>
+        /// Perform a Mouse Left Double Click Operation
+        /// </summary>
+        void LeftDoubleClick();
+
+        /// <summary>
+        /// Perform a Mouse Left Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        void LeftDoubleClick(Point point);
 
         #endregion
 

--- a/src/TestStack.White/InputDevices/IMouse.cs
+++ b/src/TestStack.White/InputDevices/IMouse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using TestStack.White.UIItems.Actions;
 
@@ -7,13 +8,6 @@ namespace TestStack.White.InputDevices
     {
         #region Mouse Click
 
-        /// <summary>
-        /// Perform a Click Operation
-        /// </summary>
-        /// <param name="point">Point where to Click on</param>
-        /// <param name="actionListener">ActionListener to use after Click Operation</param>
-        void Click(Point point, IActionListener actionListener);
-        
         /// <summary>
         /// Perform a Click Operation
         /// </summary>
@@ -40,14 +34,7 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Double Click
-
-        /// <summary>
-        /// Perform a Double Click Operation
-        /// </summary>
-        /// <param name="point">Point where to Double Click on</param>
-        /// <param name="actionListener">ActionListener to use after Click Operation</param>
-        void DoubleClick(Point point, IActionListener actionListener);
-
+        
         /// <summary>
         /// Perform a Double Click Operation
         /// </summary>
@@ -62,6 +49,44 @@ namespace TestStack.White.InputDevices
         /// <param name="point">Point where to Double Click on</param>
         /// <param name="actionListener">ActionListener to use after Click Operation</param>
         void DoubleClick(MouseButton mouseButton, Point point, IActionListener actionListener);
+
+        #endregion
+
+        #region Left Click
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        [Obsolete("Use LeftClick instead")]
+        void Click(Point point, IActionListener actionListener);
+
+        /// <summary>
+        /// Perform a Left Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void LeftClick(Point point, IActionListener actionListener);
+
+        #endregion
+
+        #region Left Double Click
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        [Obsolete("Use LeftDoubleClick instead")]
+        void DoubleClick(Point point, IActionListener actionListener);
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void LeftDoubleClick(Point point, IActionListener actionListener);
 
         #endregion
 

--- a/src/TestStack.White/InputDevices/IMouse.cs
+++ b/src/TestStack.White/InputDevices/IMouse.cs
@@ -1,16 +1,90 @@
 using System.Windows;
-using TestStack.White.UIItems;
+using TestStack.White.UIItems.Actions;
 
 namespace TestStack.White.InputDevices
 {
-    public interface IMouse
+    public interface IMouse : IBaseMouse
     {
-        Point Location { get; set; }
-        void RightClick();
-        void Click();
-        void DoubleClick(Point point);
-        void Click(Point point);
-        void DragAndDrop(IUIItem draggedItem, IUIItem dropItem);
-        void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition);
+        #region Mouse Click
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void Click(Point point, IActionListener actionListener);
+        
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to Click</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        /// <remarks>
+        /// Clicks the specified mouse button. Makes sure to not accidentaly fire a double click
+        /// if called multiple times
+        /// </remarks>
+        void Click(MouseButton mouseButton, IActionListener actionListener);
+
+        /// <summary>
+        /// Perform a Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to Click</param>
+        /// <param name="point">Point to Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        /// <remarks>
+        /// Clicks the specified mouse button. Makes sure to not accidentaly fire a double click
+        /// if called multiple times
+        /// </remarks>
+        void Click(MouseButton mouseButton, Point point, IActionListener actionListener);
+
+        #endregion
+
+        #region Double Click
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void DoubleClick(Point point, IActionListener actionListener);
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to double click</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void DoubleClick(MouseButton mouseButton, IActionListener actionListener);
+
+        /// <summary>
+        /// Perform a Double Click Operation
+        /// </summary>
+        /// <param name="mouseButton">MouseButton to double click</param>
+        /// <param name="point">Point where to Double Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void DoubleClick(MouseButton mouseButton, Point point, IActionListener actionListener);
+
+        #endregion
+
+        #region Right Click
+
+        /// <summary>
+        /// Perform a Right Click Operation
+        /// </summary>
+        /// <param name="point">Point where to Double Click on</param>
+        /// <param name="actionListener">ActionListener to use after Click Operation</param>
+        void RightClick(Point point, IActionListener actionListener);
+
+        #endregion
+
+        #region Perform Action
+
+        /// <summary>
+        /// Perform an Action on the Action Listener 
+        /// </summary>
+        /// <param name="actionListener"><see cref="IActionListener"/> to perform an Action on</param>
+        void ActionPerformed(IActionListener actionListener);
+
+        #endregion
+
     }
 }

--- a/src/TestStack.White/InputDevices/IMouse.cs
+++ b/src/TestStack.White/InputDevices/IMouse.cs
@@ -6,8 +6,6 @@ namespace TestStack.White.InputDevices
 {
     public interface IMouse : IBaseMouse
     {
-        #region Mouse Click
-
         /// <summary>
         /// Perform a Click Operation
         /// </summary>
@@ -31,10 +29,6 @@ namespace TestStack.White.InputDevices
         /// </remarks>
         void Click(MouseButton mouseButton, Point point, IActionListener actionListener);
 
-        #endregion
-
-        #region Double Click
-        
         /// <summary>
         /// Perform a Double Click Operation
         /// </summary>
@@ -49,10 +43,6 @@ namespace TestStack.White.InputDevices
         /// <param name="point">Point where to Double Click on</param>
         /// <param name="actionListener">ActionListener to use after Click Operation</param>
         void DoubleClick(MouseButton mouseButton, Point point, IActionListener actionListener);
-
-        #endregion
-
-        #region Left Click
 
         /// <summary>
         /// Perform a Left Click Operation
@@ -69,10 +59,6 @@ namespace TestStack.White.InputDevices
         /// <param name="actionListener">ActionListener to use after Click Operation</param>
         void LeftClick(Point point, IActionListener actionListener);
 
-        #endregion
-
-        #region Left Double Click
-
         /// <summary>
         /// Perform a Double Click Operation
         /// </summary>
@@ -88,10 +74,6 @@ namespace TestStack.White.InputDevices
         /// <param name="actionListener">ActionListener to use after Click Operation</param>
         void LeftDoubleClick(Point point, IActionListener actionListener);
 
-        #endregion
-
-        #region Right Click
-
         /// <summary>
         /// Perform a Right Click Operation
         /// </summary>
@@ -99,17 +81,10 @@ namespace TestStack.White.InputDevices
         /// <param name="actionListener">ActionListener to use after Click Operation</param>
         void RightClick(Point point, IActionListener actionListener);
 
-        #endregion
-
-        #region Perform Action
-
         /// <summary>
         /// Perform an Action on the Action Listener 
         /// </summary>
         /// <param name="actionListener"><see cref="IActionListener"/> to perform an Action on</param>
         void ActionPerformed(IActionListener actionListener);
-
-        #endregion
-
     }
 }

--- a/src/TestStack.White/InputDevices/Mouse.cs
+++ b/src/TestStack.White/InputDevices/Mouse.cs
@@ -1,145 +1,38 @@
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Windows;
-using TestStack.White.Configuration;
-using TestStack.White.Drawing;
-using TestStack.White.UIA;
-using TestStack.White.UIItems;
 using TestStack.White.UIItems.Actions;
-using TestStack.White.WindowsAPI;
-using Action = TestStack.White.UIItems.Actions.Action;
 
 namespace TestStack.White.InputDevices
 {
-    public class Mouse : IMouse
+    public class Mouse : BaseMouse, IMouse
     {
-        [DllImport("user32", EntryPoint = "SendInput")]
-        static extern int SendInput(uint numberOfInputs, ref Input input, int structSize);
-
-        [DllImport("user32", EntryPoint = "SendInput")]
-        static extern int SendInput64(int numberOfInputs, ref Input64 input, int structSize);
-
-        [DllImport("user32.dll")]
-        static extern IntPtr GetMessageExtraInfo();
-
-        [DllImport("user32.dll")]
-
-        static extern bool GetCursorPos(ref System.Drawing.Point cursorInfo);
-
-        [DllImport("user32.dll")]
-        static extern bool SetCursorPos(int x, int y);
-
-        [DllImport("user32.dll")]
-        static extern bool GetCursorInfo(ref CursorInfo cursorInfo);
-
-        [DllImport("user32.dll")]
-        static extern short GetDoubleClickTime();
-
-        [DllImport("user32.dll")]
-        static extern int GetSystemMetrics(SystemMetric smIndex);
+        #region Fields
 
         public static Mouse Instance = new Mouse();
-        Dictionary<MouseButton, DateTime> lastClickTimes;
-        Dictionary<MouseButton, Point> lastClickLocations;
-        readonly short doubleClickTime = GetDoubleClickTime();
-        const int ExtraMillisecondsBecauseOfBugInWindows = 13;
 
-        Mouse()
-        {
-            lastClickTimes = new Dictionary<MouseButton, DateTime>();
-            lastClickLocations = new Dictionary<MouseButton, Point>();
-            foreach (MouseButton mouseButton in Enum.GetValues(typeof(MouseButton)))
-            {
-                lastClickTimes.Add(mouseButton, DateTime.Now);
-                lastClickLocations.Add(mouseButton, new Point(0, 0));
-            }
-        }
+        #endregion
 
-        public virtual Point Location
-        {
-            get
-            {
-                var point = new System.Drawing.Point();
-                GetCursorPos(ref point);
-                return point.ConvertToWindowsPoint();
-            }
-            set
-            {
-                if (value.IsInvalid())
-                {
-                    throw new WhiteException(string.Format("Trying to set location outside the screen. {0}", value));
-                }
-                SetCursorPos((int)value.X, (int)value.Y);
-            }
-        }
+        #region Mouse Click
 
-        public virtual MouseCursor Cursor
+        /// <summary>
+        /// Implements <see cref="IMouse.Click(Point, IActionListener)"/>
+        /// </summary>
+        public virtual void Click(Point point, IActionListener actionListener)
         {
-            get
-            {
-                CursorInfo cursorInfo = CursorInfo.New();
-                GetCursorInfo(ref cursorInfo);
-                int i = cursorInfo.handle.ToInt32();
-                return new MouseCursor(i);
-            }
-        }
-
-        private static int RightMouseButtonDown
-        {
-            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTDOWN : WindowsConstants.MOUSEEVENTF_LEFTDOWN; }
-        }
-
-        private static int RightMouseButtonUp
-        {
-            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_RIGHTUP : WindowsConstants.MOUSEEVENTF_LEFTUP; }
-        }
-
-        private static int LeftMouseButtonDown
-        {
-            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTDOWN : WindowsConstants.MOUSEEVENTF_RIGHTDOWN; }
-        }
-
-        private static int LeftMouseButtonUp
-        {
-            get { return GetSystemMetrics(SystemMetric.SM_SWAPBUTTON) == 0 ? WindowsConstants.MOUSEEVENTF_LEFTUP : WindowsConstants.MOUSEEVENTF_RIGHTUP; }
+            Click(MouseButton.Left, point, actionListener);
         }
 
         /// <summary>
-        /// Clicks the specified mouse button. Makes sure to not accidentaly fire a double click
-        /// if called multiple times
+        /// Implements <see cref="IMouse.Click(MouseButton, IActionListener)"/>
         /// </summary>
-        public virtual void Click(MouseButton mouseButton)
-        {
-            var currentClickLocation = Location;
-            // Check if the location is the same as with last click
-            if (lastClickLocations[mouseButton].Equals(currentClickLocation))
-            {
-                // Get the timeout needed to not fire a double click
-                int timeout = doubleClickTime - DateTime.Now.Subtract(lastClickTimes[mouseButton]).Milliseconds;
-                // Wait the needed time to prevent the double click
-                if (timeout > 0) Thread.Sleep(timeout + ExtraMillisecondsBecauseOfBugInWindows);
-            }
-            // Perform the click
-            MouseButtonUpAndDown(mouseButton);
-            // Update the time and location
-            lastClickTimes[mouseButton] = DateTime.Now;
-            lastClickLocations[mouseButton] = Location;
-        }
-
-        public virtual void Click(MouseButton mouseButton, Point point)
-        {
-            Location = point;
-            Click(mouseButton);
-        }
-
         public virtual void Click(MouseButton mouseButton, IActionListener actionListener)
         {
             Click(mouseButton);
             ActionPerformed(actionListener);
         }
 
+        /// <summary>
+        /// Implements <see cref="IMouse.Click(MouseButton, Point, IActionListener)"/>
+        /// </summary>
         public virtual void Click(MouseButton mouseButton, Point point, IActionListener actionListener)
         {
             Location = point;
@@ -147,28 +40,30 @@ namespace TestStack.White.InputDevices
             ActionPerformed(actionListener);
         }
 
+        #endregion
+
+        #region Double Click
+
         /// <summary>
-        /// Double clicks the specified mouse button.
+        /// Implements <see cref="IMouse.DoubleClick(Point, IActionListener)"/>
         /// </summary>
-        public virtual void DoubleClick(MouseButton mouseButton)
+        public virtual void DoubleClick(Point point, IActionListener actionListener)
         {
-            MouseButtonUpAndDown(mouseButton);
-            Thread.Sleep(CoreAppXmlConfiguration.Instance.DoubleClickInterval);
-            MouseButtonUpAndDown(mouseButton);
+            DoubleClick(MouseButton.Left, point, actionListener);
         }
 
-        public virtual void DoubleClick(MouseButton mouseButton, Point point)
-        {
-            Location = point;
-            DoubleClick(mouseButton);
-        }
-
+        /// <summary>
+        /// Implements <see cref="IMouse.DoubleClick(MouseButton, IActionListener)"/>
+        /// </summary>
         public virtual void DoubleClick(MouseButton mouseButton, IActionListener actionListener)
         {
             DoubleClick(mouseButton);
             ActionPerformed(actionListener);
         }
 
+        /// <summary>
+        /// Implements <see cref="IMouse.DoubleClick(MouseButton, Point, IActionListener)"/>
+        /// </summary>
         public virtual void DoubleClick(MouseButton mouseButton, Point point, IActionListener actionListener)
         {
             Location = point;
@@ -176,239 +71,33 @@ namespace TestStack.White.InputDevices
             ActionPerformed(actionListener);
         }
 
-        /// <summary>
-        /// Performs a down / up sequence for the specified button
-        /// </summary>
-        private static void MouseButtonUpAndDown(MouseButton mouseButton)
-        {
-            MouseButtonDown(mouseButton);
-            MouseButtonUp(mouseButton);
-        }
+        #endregion
+
+        #region Right Click
 
         /// <summary>
-        /// Performs a down for the specified button
+        /// Implements <see cref="IMouse.RightClick(Point, IActionListener)"/>
         /// </summary>
-        private static void MouseButtonDown(MouseButton mouseButton)
-        {
-            SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, true)));
-        }
-
-        /// <summary>
-        /// Performs an up for the specified button
-        /// </summary>
-        private static void MouseButtonUp(MouseButton mouseButton)
-        {
-            SendInput(InputFactory.Mouse(GetInputForButton(mouseButton, false)));
-        }
-
-        /// <summary>
-        /// Generates the input object for the button
-        /// </summary>
-        /// <param name="mouseButton">The button to get the input for</param>
-        /// <param name="isDown">Flag if down is wanted, up otherwise</param>
-        private static MouseInput GetInputForButton(MouseButton mouseButton, bool isDown)
-        {
-            switch (mouseButton)
-            {
-                case MouseButton.Left:
-                    return MouseInput(isDown ? LeftMouseButtonDown : LeftMouseButtonUp);
-                case MouseButton.Right:
-                    return MouseInput(isDown ? RightMouseButtonDown : RightMouseButtonUp);
-                case MouseButton.Middle:
-                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_MIDDLEDOWN : WindowsConstants.MOUSEEVENTF_MIDDLEUP);
-                case MouseButton.XButton1:
-                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_XDOWN : WindowsConstants.MOUSEEVENTF_XUP, 0x0001);
-                case MouseButton.XButton2:
-                    return MouseInput(isDown ? WindowsConstants.MOUSEEVENTF_XDOWN : WindowsConstants.MOUSEEVENTF_XUP, 0x0002);
-                default:
-                    throw new ArgumentOutOfRangeException("mouseButton", "Unknown mouse button");
-            }
-        }
-
-        /// <summary>
-        /// Performs a left click
-        /// </summary>
-        public virtual void Click()
-        {
-            Click(MouseButton.Left);
-        }
-
-        public virtual void Click(Point point)
-        {
-            Click(MouseButton.Left, point);
-        }
-
-        public virtual void Click(Point point, IActionListener actionListener)
-        {
-            Click(MouseButton.Left, point, actionListener);
-        }
-
-        /// <summary>
-        /// Performs a right click
-        /// </summary>
-        public virtual void RightClick()
-        {
-            Click(MouseButton.Right);
-        }
-
-        public virtual void RightClick(Point point)
-        {
-            Click(MouseButton.Right, point);
-        }
-
         public virtual void RightClick(Point point, IActionListener actionListener)
         {
             Click(MouseButton.Right, point, actionListener);
         }
 
+        #endregion
+
+        #region Public
+
         /// <summary>
-        /// Performs a left double click
+        /// Implements <see cref="IMouse.ActionPerformed(IActionListener)"/>
         /// </summary>
-        public virtual void DoubleClick(Point point)
-        {
-            DoubleClick(MouseButton.Left, point);
-        }
-
-        public virtual void DoubleClick(Point point, IActionListener actionListener)
-        {
-            DoubleClick(MouseButton.Left, point, actionListener);
-        }
-
-        public static void LeftUp()
-        {
-            MouseButtonUp(MouseButton.Left);
-        }
-
-        public static void LeftDown()
-        {
-            MouseButtonDown(MouseButton.Left);
-        }
-
-        public static void RightUp()
-        {
-            MouseButtonUp(MouseButton.Right);
-        }
-
-        public static void RightDown()
-        {
-            MouseButtonDown(MouseButton.Right);
-        }
-
-        public static void MouseLeftButtonUpAndDown()
-        {
-            LeftDown();
-            LeftUp();
-        }
-
-        private static void SendInput(Input input)
-        {
-            // Added check for 32/64 bit  
-            if (IntPtr.Size == 4)
-                SendInput(1, ref input, Marshal.SizeOf(typeof(Input)));
-            else
-            {
-                var input64 = new Input64(input);
-                SendInput64(1, ref input64, Marshal.SizeOf(typeof(Input)));
-            }
-        }
-
-        private static MouseInput MouseInput(int command, int mouseData = 0)
-        {
-            return new MouseInput(command, GetMessageExtraInfo(), mouseData);
-        }
-
-        private static void ActionPerformed(IActionListener actionListener)
+        /// <remarks>
+        /// Overrides the <see cref="BaseMouse.ActionPerformed"/> abstract Function
+        /// </remarks>
+        public override void ActionPerformed(IActionListener actionListener)
         {
             actionListener.ActionPerformed(new Action(ActionType.WindowMessage));
         }
 
-        /// <summary>
-        /// Drags the dragged item and drops it on the drop item. This can be used for any two UIItems
-        /// whether they are same application or different. To drop items on desktop use Desktop 
-        /// class's Drop method. White starts and ends the drag from center of the UIItems.
-        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
-        /// This can be set but configuring DragStepCount property. This is by default set to 1.
-        /// </summary>
-        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, IUIItem dropItem)
-        {
-            Point startPosition = draggedItem.Bounds.Center();
-            Point endPosition = dropItem.Bounds.Center();
-            DragAndDrop(mouseButton, draggedItem, startPosition, dropItem, endPosition);
-        }
-
-        public virtual void DragAndDrop(IUIItem draggedItem, IUIItem dropItem)
-        {
-            DragAndDrop(MouseButton.Left, draggedItem, dropItem);
-        }
-
-        /// <summary>
-        /// Drags the dragged item and drops it on the drop item. This can be used for any two UIItems
-        /// whether they are same application or different. To drop items on desktop use Desktop 
-        /// class's Drop method. White starts and ends the drag from center of the UIItems.
-        /// Some drag and drop operation need to wait for application to process something while item is being dragged.
-        /// This can be set but configuring DragStepCount property. This is by default set to 1.
-        /// </summary>
-        /// <param name="mouseButton">The mouse button used for dragging</param>
-        /// <param name="draggedItem"></param>
-        /// <param name="startPosition">Start point of the drag. You can do uiItem.Bounds to get bounds of the UIItem and use RectX extension class in White.Core.UIA namespace to find different points</param>
-        /// <param name="dropItem"></param>
-        /// <param name="endPosition">End point of the drag. You can do uiItem.Bounds to get bounds of the UIItem and use RectX extension class in White.Core.UIA namespace to find different points</param>
-        public virtual void DragAndDrop(MouseButton mouseButton, IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
-        {
-            Location = startPosition;
-            MouseButtonDown(mouseButton);
-            var dragStepFraction = (float)(1.0 / CoreAppXmlConfiguration.Instance.DragStepCount);
-            for (int i = 1; i <= CoreAppXmlConfiguration.Instance.DragStepCount; i++)
-            {
-                var newX = startPosition.X + (endPosition.X - startPosition.X) * (dragStepFraction * i);
-                var newY = startPosition.Y + (endPosition.Y - startPosition.Y) * (dragStepFraction * i);
-                var newPoint = new Point((int)newX, (int)newY);
-                Location = newPoint;
-            }
-            MouseButtonUp(mouseButton);
-            dropItem.ActionPerformed(Action.WindowMessage);
-        }
-
-        public virtual void DragAndDrop(IUIItem draggedItem, Point startPosition, IUIItem dropItem, Point endPosition)
-        {
-            DragAndDrop(MouseButton.Left, draggedItem, startPosition, dropItem, endPosition);
-        }
-
-        public virtual void DragHorizontally(MouseButton mouseButton, UIItem uiItem, int distance)
-        {
-            Location = uiItem.Bounds.Center();
-            var currentXLocation = Location.X;
-            var currentYLocation = Location.Y;
-            MouseButtonDown(mouseButton);
-            ActionPerformed(uiItem);
-            Location = new Point(currentXLocation + distance, currentYLocation);
-            MouseButtonUp(mouseButton);
-        }
-
-        public virtual void DragVertically(MouseButton mouseButton, UIItem uiItem, int distance)
-        {
-            Location = uiItem.Bounds.Center();
-            var currentXLocation = Location.X;
-            var currentYLocation = Location.Y;
-            MouseButtonDown(mouseButton);
-            ActionPerformed(uiItem);
-            Location = new Point(currentXLocation, currentYLocation + distance);
-            MouseButtonUp(mouseButton);
-        }
-
-        public virtual void DragHorizontally(UIItem uiItem, int distance)
-        {
-            DragHorizontally(MouseButton.Left, uiItem, distance);
-        }
-
-        public virtual void DragVertically(UIItem uiItem, int distance)
-        {
-            DragVertically(MouseButton.Left, uiItem, distance);
-        }
-
-        public virtual void MoveOut()
-        {
-            Location = new Point(0, 0);
-        }
+        #endregion
     }
 }

--- a/src/TestStack.White/InputDevices/Mouse.cs
+++ b/src/TestStack.White/InputDevices/Mouse.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Windows;
 using TestStack.White.UIItems.Actions;
+using Action = TestStack.White.UIItems.Actions.Action;
 
 namespace TestStack.White.InputDevices
 {
@@ -12,14 +14,6 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Mouse Click
-
-        /// <summary>
-        /// Implements <see cref="IMouse.Click(Point, IActionListener)"/>
-        /// </summary>
-        public virtual void Click(Point point, IActionListener actionListener)
-        {
-            Click(MouseButton.Left, point, actionListener);
-        }
 
         /// <summary>
         /// Implements <see cref="IMouse.Click(MouseButton, IActionListener)"/>
@@ -43,15 +37,7 @@ namespace TestStack.White.InputDevices
         #endregion
 
         #region Double Click
-
-        /// <summary>
-        /// Implements <see cref="IMouse.DoubleClick(Point, IActionListener)"/>
-        /// </summary>
-        public virtual void DoubleClick(Point point, IActionListener actionListener)
-        {
-            DoubleClick(MouseButton.Left, point, actionListener);
-        }
-
+        
         /// <summary>
         /// Implements <see cref="IMouse.DoubleClick(MouseButton, IActionListener)"/>
         /// </summary>
@@ -69,6 +55,48 @@ namespace TestStack.White.InputDevices
             Location = point;
             DoubleClick(mouseButton);
             ActionPerformed(actionListener);
+        }
+
+        #endregion
+
+        #region Left Click
+
+        /// <summary>
+        /// Implements <see cref="IMouse.Click(Point, IActionListener)"/>
+        /// </summary>
+        [Obsolete("Use LeftClick instead")]
+        public virtual void Click(Point point, IActionListener actionListener)
+        {
+            Click(MouseButton.Left, point, actionListener);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IMouse.LeftClick(Point, IActionListener)"/>
+        /// </summary>
+        public virtual void LeftClick(Point point, IActionListener actionListener)
+        {
+            Click(MouseButton.Left, point, actionListener);
+        }
+
+        #endregion
+
+        #region Left Double Click
+        
+        /// <summary>
+        /// Implements <see cref="IMouse.DoubleClick(Point, IActionListener)"/>
+        /// </summary>
+        [Obsolete("Use LeftDoubleClick instead")]
+        public virtual void DoubleClick(Point point, IActionListener actionListener)
+        {
+            DoubleClick(MouseButton.Left, point, actionListener);
+        }
+
+        /// <summary>
+        /// Implements <see cref="IMouse.LeftDoubleClick(Point, IActionListener)"/>
+        /// </summary>
+        public virtual void LeftDoubleClick(Point point, IActionListener actionListener)
+        {
+            DoubleClick(MouseButton.Left, point, actionListener);
         }
 
         #endregion

--- a/src/TestStack.White/InputDevices/Mouse.cs
+++ b/src/TestStack.White/InputDevices/Mouse.cs
@@ -7,13 +7,8 @@ namespace TestStack.White.InputDevices
 {
     public class Mouse : BaseMouse, IMouse
     {
-        #region Fields
-
+        [Obsolete("Obsolete. Create an instance via new where you need it")]
         public static Mouse Instance = new Mouse();
-
-        #endregion
-
-        #region Mouse Click
 
         /// <summary>
         /// Implements <see cref="IMouse.Click(MouseButton, IActionListener)"/>
@@ -34,10 +29,6 @@ namespace TestStack.White.InputDevices
             ActionPerformed(actionListener);
         }
 
-        #endregion
-
-        #region Double Click
-        
         /// <summary>
         /// Implements <see cref="IMouse.DoubleClick(MouseButton, IActionListener)"/>
         /// </summary>
@@ -57,10 +48,6 @@ namespace TestStack.White.InputDevices
             ActionPerformed(actionListener);
         }
 
-        #endregion
-
-        #region Left Click
-
         /// <summary>
         /// Implements <see cref="IMouse.Click(Point, IActionListener)"/>
         /// </summary>
@@ -78,10 +65,6 @@ namespace TestStack.White.InputDevices
             Click(MouseButton.Left, point, actionListener);
         }
 
-        #endregion
-
-        #region Left Double Click
-        
         /// <summary>
         /// Implements <see cref="IMouse.DoubleClick(Point, IActionListener)"/>
         /// </summary>
@@ -99,10 +82,6 @@ namespace TestStack.White.InputDevices
             DoubleClick(MouseButton.Left, point, actionListener);
         }
 
-        #endregion
-
-        #region Right Click
-
         /// <summary>
         /// Implements <see cref="IMouse.RightClick(Point, IActionListener)"/>
         /// </summary>
@@ -110,10 +89,6 @@ namespace TestStack.White.InputDevices
         {
             Click(MouseButton.Right, point, actionListener);
         }
-
-        #endregion
-
-        #region Public
 
         /// <summary>
         /// Implements <see cref="IMouse.ActionPerformed(IActionListener)"/>
@@ -125,7 +100,5 @@ namespace TestStack.White.InputDevices
         {
             actionListener.ActionPerformed(new Action(ActionType.WindowMessage));
         }
-
-        #endregion
     }
 }

--- a/src/TestStack.White/TestStack.White.csproj
+++ b/src/TestStack.White/TestStack.White.csproj
@@ -95,7 +95,10 @@
     <Compile Include="Configuration\WhiteDefaultLogger.cs" />
     <Compile Include="Configuration\WhiteDefaultLoggerFactory.cs" />
     <Compile Include="Drawing\ScreenRectangle.cs" />
+    <Compile Include="InputDevices\IBaseMouse.cs" />
     <Compile Include="InputDevices\Input64.cs" />
+    <Compile Include="InputDevices\BareMetalMouse.cs" />
+    <Compile Include="InputDevices\BaseMouse.cs" />
     <Compile Include="InputDevices\MouseButton.cs" />
     <Compile Include="InputDevices\SystemMetric.cs" />
     <Compile Include="Interceptors\IWhiteInterceptor.cs" />

--- a/src/TestStack.White/UIItemEvents/ListViewEvent.cs
+++ b/src/TestStack.White/UIItemEvents/ListViewEvent.cs
@@ -37,7 +37,8 @@ namespace TestStack.White.UIItemEvents
 
         public static UserEvent Create(ListView listView, AutomationPropertyChangedEventArgs eventArgs)
         {
-            var columnPosition = (int) Mouse.Instance.Location.X;
+            var mouse = new Mouse();
+            var columnPosition = (int)mouse.Location.X;
             if (listView.SelectedRows.Count == 0)
             {
                 var listViewEvent = new ListViewEvent(listView, TryUnSelectAll, new object[] {});

--- a/src/TestStack.White/UIItems/Hyperlink.cs
+++ b/src/TestStack.White/UIItems/Hyperlink.cs
@@ -14,7 +14,7 @@ namespace TestStack.White.UIItems
         {
             double x = automationElement.Current.BoundingRectangle.X + xOffset;
             double y = automationElement.Current.BoundingRectangle.Y + yOffset;
-            mouse.Click(new Point((int) x, (int) y), actionListener);
+            mouse.LeftClick(new Point((int) x, (int) y), actionListener);
         }
 
         public override void HookEvents(IUIItemEventListener eventListener)

--- a/src/TestStack.White/UIItems/ListBoxItems/ListItem.cs
+++ b/src/TestStack.White/UIItems/ListBoxItems/ListItem.cs
@@ -47,7 +47,7 @@ namespace TestStack.White.UIItems.ListBoxItems
             {
                 Logger.Debug("Selecting item with Click");
                 WaitForBoundsToStabilise(this);
-                mouse.Click(Bounds.ImmediateInteriorEast(), actionListener);
+                mouse.LeftClick(Bounds.ImmediateInteriorEast(), actionListener);
                 if (!IsSelected)
                 {
                     Logger.Debug("Failed to select list item via click. Falling back to automation patterns");

--- a/src/TestStack.White/UIItems/ListViewRow.cs
+++ b/src/TestStack.White/UIItems/ListViewRow.cs
@@ -68,7 +68,7 @@ namespace TestStack.White.UIItems
             {
                 throw new WhiteException(string.Format("Failed to select {0}, clickable point empty", ToString()));
             }
-            mouse.Click(clickablePoint, actionListener);
+            mouse.LeftClick(clickablePoint, actionListener);
         }
 
         /// <summary>

--- a/src/TestStack.White/UIItems/TableItems/TableVerticalScrollBar.cs
+++ b/src/TestStack.White/UIItems/TableItems/TableVerticalScrollBar.cs
@@ -19,12 +19,12 @@ namespace TestStack.White.UIItems.TableItems
 
         public virtual void ScrollUp()
         {
-            mouse.Click(Bounds.ImmediateInteriorNorth(), actionListener);
+            mouse.LeftClick(Bounds.ImmediateInteriorNorth(), actionListener);
         }
 
         public virtual void ScrollDown()
         {
-            mouse.Click(Bounds.ImmediateInteriorSouth(), actionListener);
+            mouse.LeftClick(Bounds.ImmediateInteriorSouth(), actionListener);
         }
 
         public virtual void ScrollUpLarge()

--- a/src/TestStack.White/UIItems/TextBox.cs
+++ b/src/TestStack.White/UIItems/TextBox.cs
@@ -69,12 +69,12 @@ namespace TestStack.White.UIItems
 
         public virtual void ClickAtRightEdge()
         {
-            mouse.Click(Bounds.ImmediateInteriorEast(), actionListener);
+            mouse.LeftClick(Bounds.ImmediateInteriorEast(), actionListener);
         }
 
         public virtual void ClickAtCenter()
         {
-            mouse.Click(Bounds.Center(), actionListener);
+            mouse.LeftClick(Bounds.Center(), actionListener);
         }
 
         public override void HookEvents(IUIItemEventListener eventListener)

--- a/src/TestStack.White/UIItems/TooltipSafeMouse.cs
+++ b/src/TestStack.White/UIItems/TooltipSafeMouse.cs
@@ -39,11 +39,11 @@ namespace TestStack.White.UIItems
             actionListener.ActionPerforming(uiItem);
             ToolTip toolTip = GetToolTip(uiItem, actionListener);
             if (toolTip == null)
-                mouse.DoubleClick(uiItem.Bounds.Center(), actionListener);
+                mouse.LeftDoubleClick(uiItem.Bounds.Center(), actionListener);
             else
             {
                 logger.Debug("Found tooltip DoubleClicking outside tooltip bounds");
-                mouse.DoubleClick(toolTip.LeftOutside(uiItem.Bounds), actionListener);
+                mouse.LeftDoubleClick(toolTip.LeftOutside(uiItem.Bounds), actionListener);
             }
         }
 
@@ -52,17 +52,17 @@ namespace TestStack.White.UIItems
             actionListener.ActionPerforming(uiItem);
             ToolTip toolTip = GetToolTip(uiItem, actionListener);
             if (toolTip == null)
-                mouse.Click(uiItem.Bounds.Center(), actionListener);
+                mouse.LeftClick(uiItem.Bounds.Center(), actionListener);
             else
             {
                 logger.Debug("Found tooltip Clicking outside tooltip bounds");
-                mouse.Click(toolTip.LeftOutside(uiItem.Bounds), actionListener);
+                mouse.LeftClick(toolTip.LeftOutside(uiItem.Bounds), actionListener);
             }
         }
 
         private ToolTip GetToolTip(UIItem uiItem, IActionListener actionListener)
         {
-            mouse.Click(uiItem.Bounds.Center());
+            mouse.LeftClick(uiItem.Bounds.Center());
             actionListener.ActionPerformed(Action.WindowMessage);
             Thread.Sleep(CoreAppXmlConfiguration.Instance.TooltipWaitTime);
             return ToolTip.GetFrom(uiItem.Bounds.Center());

--- a/src/TestStack.White/UIItems/TreeItems/ClickedNodeVisitor.cs
+++ b/src/TestStack.White/UIItems/TreeItems/ClickedNodeVisitor.cs
@@ -1,3 +1,4 @@
+using System;
 using TestStack.White.InputDevices;
 
 namespace TestStack.White.UIItems.TreeItems
@@ -13,7 +14,8 @@ namespace TestStack.White.UIItems.TreeItems
 
         public virtual void Accept(TreeNode treeNode)
         {
-            if (treeNode.Bounds.Top <= Mouse.Instance.Location.Y && treeNode.Bounds.Bottom >= Mouse.Instance.Location.Y)
+            var mouse = new Mouse();
+            if (treeNode.Bounds.Top <= mouse.Location.Y && treeNode.Bounds.Bottom >= mouse.Location.Y)
                 clickedNode = treeNode;
         }
     }

--- a/src/TestStack.White/UIItems/TreeItems/TreeNode.cs
+++ b/src/TestStack.White/UIItems/TreeItems/TreeNode.cs
@@ -54,7 +54,7 @@ namespace TestStack.White.UIItems.TreeItems
         public virtual void Select()
         {
             actionListener.ActionPerforming(this);
-            mouse.Click(SelectPoint, actionListener);
+            mouse.LeftClick(SelectPoint, actionListener);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace TestStack.White.UIItems.TreeItems
         public override void DoubleClick()
         {
             actionListener.ActionPerforming(this);
-            mouse.DoubleClick(SelectPoint, actionListener);
+            mouse.LeftDoubleClick(SelectPoint, actionListener);
         }
 
         public override void RightClick()

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -329,7 +329,7 @@ namespace TestStack.White.UIItems
         public virtual void DoubleClick()
         {
             actionListener.ActionPerforming(this);
-            PerformIfValid(() => mouse.DoubleClick(Bounds.Center(), actionListener));
+            PerformIfValid(() => mouse.LeftDoubleClick(Bounds.Center(), actionListener));
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace TestStack.White.UIItems
             {
                 throw new WhiteException(string.Format("Failed to click on {0}, bounds empty", ToString()));
             }
-            mouse.Click(bounds.Center(), actionListener);
+            mouse.LeftClick(bounds.Center(), actionListener);
         }
 
         #endregion

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -31,7 +31,7 @@ namespace TestStack.White.UIItems
 
         protected readonly AutomationElement automationElement;
         protected IActionListener actionListener;
-        internal static readonly Mouse mouse = Mouse.Instance;
+        internal static readonly Mouse mouse = new Mouse();
         protected readonly PrimaryUIItemFactory factory;
         internal readonly Keyboard keyboard = Keyboard.Instance;
         protected IScrollBars scrollBars;

--- a/src/TestStack.White/UIItems/WindowItems/Window.cs
+++ b/src/TestStack.White/UIItems/WindowItems/Window.cs
@@ -197,13 +197,13 @@ UI actions on window needing mouse would not work in area not falling under the 
             if (!CoreAppXmlConfiguration.Instance.WaitBasedOnHourGlass) return;
             try
             {
-                Retry.For(() => InputDevices.Mouse.Instance.Cursor,
+                Retry.For(() => mouse.Cursor,
                           cursor =>
                           {
                               if (MouseCursor.WaitCursors.Contains(cursor))
                               {
                                   if (CoreAppXmlConfiguration.Instance.MoveMouseToGetStatusOfHourGlass)
-                                      InputDevices.Mouse.Instance.MoveOut();
+                                      mouse.MoveOut();
                                   return true;
                               }
                               return false;
@@ -211,7 +211,7 @@ UI actions on window needing mouse would not work in area not falling under the 
             }
             catch (Exception)
             {
-                throw new UIActionException(string.Format("Window in still wait mode. Cursor: {0}{1}", InputDevices.Mouse.Instance.Cursor, Constants.BusyMessage));
+                throw new UIActionException(string.Format("Window in still wait mode. Cursor: {0}{1}", mouse.Cursor, Constants.BusyMessage));
             }
         }
 


### PR DESCRIPTION
Cleaning up the Mouse Classes and Interfaces
This 'should' not break current implementation. 
It's just separating some of the code into manageable chunks.

BareMetalMouse
+ Added new Class called BareMetalMouse
+ Contains the DLLImport from user32
+ Contains the basic Button Interactions

IBaseMouse / BaseMouse
+ New Interface called IBaseMouse
+ New Abstract Class called BaseMouse
+ Moved most of the Functions from Mouse to BaseMouse
+ Interface now reflects all the public Functions and Properties from
the Class
+ BaseMouse contains all interactions that do not directly require an
ActionPerformed on the IActionListener

IMouse / Mouse
+ Cleaned up Mouse -> Move the Bare Mouse work to BareMetalMouse
+ Cleaned up Mouse -> Moved general Mouse Work to BaseMouse
+ Mouse now only contains the code for Mouse Interaction sporting an
IActionListener
+ Interface reflects the public Functions and properties

AttachedMouse
+ Inherits from IBaseMouse now
+ Offering more Function Calls now
+ On Operations where Mouse offers a version with IActionListener, that
Function is called
+ On Operations where Mouse does not offer an IActionListener call,, the
ActionPerformed Function from Mouse is called