### PR TITLE
AsContainer functionality moved to internal to prevent problems in Get and Exist methods

### DIFF
--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -527,6 +527,15 @@ namespace TestStack.White.UIItems
         /// <returns>Returns an <c><see cref="IUIItemContainer"/></c> if possibe</returns>
         public virtual IUIItemContainer AsContainer()
         {
+            return AsContainerInternal();
+        }
+
+        #endregion
+
+        #region Internal
+
+        internal virtual IUIItemContainer AsContainerInternal()
+        {
             if (Framework != WindowsFramework.Wpf)
             {
                 Logger.Warn("Only WPF items should be treated as container items");

--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -536,6 +536,9 @@ namespace TestStack.White.UIItems
 
         internal virtual IUIItemContainer AsContainerInternal()
         {
+            // This function needs to be internal because all public method from this
+            // class call interceptors. Sometimes we don't need focus on element, for
+            // example in GetMultiple method, so this method created for internal usage.
             if (Framework != WindowsFramework.Wpf)
             {
                 Logger.Warn("Only WPF items should be treated as container items");

--- a/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
+++ b/src/TestStack.White/UIItems/WPFUIItems/WPFUIItem.cs
@@ -144,7 +144,7 @@ namespace TestStack.White.UIItems.WPFUIItems
             {
                 throw new WhiteException("Cannot get UI Item container, uiItem must be an instance of UIItem");
             }
-            return item.AsContainer();
+            return item.AsContainerInternal();
         }
 
         #endregion


### PR DESCRIPTION
We have public AsContainer fuction in UIItem and all calls of public funtions (exept properties) calls Interceptor, Focus for example. And we use AsContainer function in GetMultiple function so we have problem: when we seach for an item we interceptors because AsContainer is public. So I moved this function functionality in AsContainerInternal function, and use this function for internal contaner usage. You can still AsContainer public function if you want with  interceptors.