### PR TITLE
empty frameworkID fix

### DIFF
--- a/src/TestStack.White/Mappings/ControlDictionary.cs
+++ b/src/TestStack.White/Mappings/ControlDictionary.cs
@@ -215,8 +215,17 @@ namespace TestStack.White.Mappings
 
         public virtual Type GetTestControlType(AutomationElement automationElement)
         {
+            TreeWalker tWalker = TreeWalker.ControlViewWalker;
             AutomationElement.AutomationElementInformation current = automationElement.Current;
-            return GetTestControlType(current.ClassName, current.Name, current.ControlType, current.FrameworkId, current.NativeWindowHandle != 0);
+            AutomationElement parent = tWalker.GetParent(automationElement);
+            String frameId = current.FrameworkId;
+            while (string.IsNullOrEmpty(frameId) || tWalker.GetParent(parent) != null)
+            {
+                frameId = parent.Current.FrameworkId;
+                parent = tWalker.GetParent(parent);
+            }
+
+            return GetTestControlType(current.ClassName, current.Name, current.ControlType, frameId, current.NativeWindowHandle != 0);
         }
     }
 }


### PR DESCRIPTION
If a frameworkId is not set in a AutomationElement, I make an attempt to climb up the parent chain to find one. This avoids a Label element lookup returning multiple ControlType matches. 