### PR TITLE
Extend Allotted Time to Expand ListControl Element

### DIFF
--- a/src/TestStack.White/UIItems/ListBoxItems/ListControl.cs
+++ b/src/TestStack.White/UIItems/ListBoxItems/ListControl.cs
@@ -42,13 +42,16 @@ namespace TestStack.White.UIItems.ListBoxItems
 
             if (!AutomationElement.TryGetCurrentPattern(ExpandCollapsePattern.Pattern, out expandCollapse)) return;
 
-            var state = (ExpandCollapseState) automationElement
-                .GetCurrentPropertyValue(ExpandCollapsePattern.ExpandCollapseStateProperty);
-            if (state == ExpandCollapseState.Collapsed)
-            {
-                ((ExpandCollapsePattern)expandCollapse).Expand();
+            ExpandCollapseState state;
+            do {
+                state = (ExpandCollapseState) automationElement
+                    .GetCurrentPropertyValue(ExpandCollapsePattern.ExpandCollapseStateProperty);
+                if (state == ExpandCollapseState.Collapsed)
+                {
+                    ((ExpandCollapsePattern)expandCollapse).Expand();
+                }
                 Thread.Sleep(50);
-            }
+            } while (state != ExpandCollapseState.Expanded);
         }
 
         public virtual ListItem Item(string itemText)


### PR DESCRIPTION
I hit an issue in my project where the 50ms to expand the combo box was not long enough. 
When reading Items.SelectedItemText, I was getting the incorrect value as the combo box was not fully expanded within the allotted time. 

This solution allows more time for slower combo boxes without adding any extra sleeping to combo boxes that don't need it.