### PR TITLE
UIItem defaults to NullActionListener if no IActionListener provided

### DIFF
--- a/src/TestStack.White/UIItems/UIItem.cs
+++ b/src/TestStack.White/UIItems/UIItem.cs
@@ -51,7 +51,7 @@ namespace TestStack.White.UIItems
         {
             if (null == automationElement) throw new NullReferenceException();
             this.automationElement = automationElement;
-            this.actionListener = actionListener;
+            this.actionListener = actionListener ?? new NullActionListener();
             factory = new PrimaryUIItemFactory(new AutomationElementFinder(automationElement));
         }
 


### PR DESCRIPTION
I found White failing in random places (most often in UIItem.Focus()) if object graph was started with ActionListener-less root container. 