### PR TITLE
added timeout when waiting for process idle state

### DIFF
--- a/src/TestStack.White/UIItems/WindowItems/Window.cs
+++ b/src/TestStack.White/UIItems/WindowItems/Window.cs
@@ -246,7 +246,7 @@ UI actions on window needing mouse would not work in area not falling under the 
         /// <exception cref="System.ArgumentException">when current process is not available any more (id expired)</exception>
         protected virtual void WaitForProcess()
         {
-            Process.GetProcessById(automationElement.Current.ProcessId).WaitForInputIdle();
+            Process.GetProcessById(automationElement.Current.ProcessId).WaitForInputIdle(CoreAppXmlConfiguration.Instance.BusyTimeout);
         }
 
         public override void ActionPerformed(Action action)


### PR DESCRIPTION
Fixing #510:

Added busy timeout to `Process.WaitForInputIdle` during `Window.WaitWhileBusy` to avoid waiting for a hanging process forever.