### PR TITLE
If TableCells cannot be found as descendants of the Table then look for cells in the Row

### DIFF
--- a/src/TestStack.White/Factory/TableCellFactory.cs
+++ b/src/TestStack.White/Factory/TableCellFactory.cs
@@ -31,6 +31,8 @@ namespace TestStack.White.Factory
                 return name.EndsWith(rowNameSuffix);
             };
             List<AutomationElement> tableCellElements = customControlTypes.FindAll(cellPredicate);
+            if (tableCellElements.Count > 0) return new TableCells(tableCellElements, tableHeader, actionListener);
+            tableCellElements = new AutomationElementFinder(rowElement).Descendants(AutomationSearchCondition.ByControlType(ControlType.DataItem));
             return new TableCells(tableCellElements, tableHeader, actionListener);
         }
     }


### PR DESCRIPTION
Some times, TableCells cannot be found as descendants of the Table in these case look for cells as descendats of the Row.

Please review this code and I hope you can add it to the UIAComWrapper branch!

Best regards!

++luisalonsogg