### PR TITLE
Changed access type of ChildWindowFactory.Create() to public

### DIFF
--- a/src/TestStack.White/Factory/ChildWindowFactory.cs
+++ b/src/TestStack.White/Factory/ChildWindowFactory.cs
@@ -46,7 +46,7 @@ namespace TestStack.White.Factory
         }
 
         /// <exception cref="UIItemSearchException">The application type is not supported by White</exception>
-        internal static Window Create(AutomationElement element, InitializeOption option, WindowSession windowSession)
+        public static Window Create(AutomationElement element, InitializeOption option, WindowSession windowSession)
         {
             ISpecializedWindowFactory specializedWindowFactory = SpecializedWindowFactories.Find(factory => factory.DoesSpecializeInThis(element));
             if (specializedWindowFactory != null)


### PR DESCRIPTION
Sometimes you want to create a Modal window that is not a direct child of the Main window. Current implementation of ChildWindowFactory.ModalWindow() only search windows as direct children.
My contribution provides a way to avoid this limitation.

Please review this code and I hope you can add it to the UIAComWrapper branch!

Best regards!

++luisalonsogg