### PR TITLE
Related to Issue #277 - Failing to right click on TreeNode

### DIFF
--- a/src/TestStack.White/Mappings/ControlDictionary.cs
+++ b/src/TestStack.White/Mappings/ControlDictionary.cs
@@ -219,7 +219,7 @@ namespace TestStack.White.Mappings
             AutomationElement.AutomationElementInformation current = automationElement.Current;
             AutomationElement parent = tWalker.GetParent(automationElement);
             String frameId = current.FrameworkId;
-            while (string.IsNullOrEmpty(frameId) || tWalker.GetParent(parent) != null)
+            while (string.IsNullOrEmpty(frameId) && tWalker.GetParent(parent) != null)
             {
                 frameId = parent.Current.FrameworkId;
                 parent = tWalker.GetParent(parent);


### PR DESCRIPTION
After bringing in the previous change of this file, I was able to call the Get method properly (I had been experiencing the same issue identified in Issue #277 ); however, I did have some issues with TreeNodes not being able to right click.  With the previous version, the frameId was climbing the entire tree before resolving.  Modified to resolve with the FrameworkId of the first ancestor that has one.