### PR TITLE
update TreeNodes:matchingnode to support regx compare and ignore case

### DIFF
--- a/src/TestStack.White/UIItems/TreeItems/TreeNodes.cs
+++ b/src/TestStack.White/UIItems/TreeItems/TreeNodes.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Windows.Automation;
 using TestStack.White.AutomationElementSearch;
 using TestStack.White.Factory;
@@ -32,7 +33,7 @@ namespace TestStack.White.UIItems.TreeItems
 
         private TreeNode MatchingNode(string nodeText)
         {
-            return Find(treeNode => treeNode.Text.Equals(nodeText));
+            return Find(treeNode => Regex.IsMatch(treeNode.AutomationElement.Current.Name, nodeText, RegexOptions.IgnoreCase));
         }
 
         /// <summary>


### PR DESCRIPTION
it's very limited if we use text equal, in many suituations, for windows directoties, the name is actually ignore cases.  And also like folder browser below, sometimes, the tree maybe dynamic and if we support regex compare using Node("Desktop", "Computer", ""^*\\(C:\\)*"", that would be better.

Desktop->computer->Local Disk (C:)
Desktop->computer->System (C:)