### PR TITLE
Support for CustomUI control value pattern & null exception prevention

### DIFF
--- a/src/TestStack.White/Mappings/ControlDictionary.cs
+++ b/src/TestStack.White/Mappings/ControlDictionary.cs
@@ -219,11 +219,24 @@ namespace TestStack.White.Mappings
             AutomationElement.AutomationElementInformation current = automationElement.Current;
             AutomationElement parent = tWalker.GetParent(automationElement);
             String frameId = current.FrameworkId;
-            while (string.IsNullOrEmpty(frameId) || tWalker.GetParent(parent) != null)
+
+            // This has to be in a try catch block because otherwise custom Windows Forms controls can cause exception if they have null parent
+            // as IRawElementProviderFragmentRoot should have according to documentation
+            try
             {
-                frameId = parent.Current.FrameworkId;
-                parent = tWalker.GetParent(parent);
+                while (string.IsNullOrEmpty(frameId) || tWalker.GetParent(parent) != null)
+                {
+                    frameId = parent.Current.FrameworkId;
+                    parent = tWalker.GetParent(parent);
+                }
             }
+            catch
+            {
+                // Catch possible null reference exception
+                frameId = String.Empty;
+                parent = null;
+            }
+
 
             return GetTestControlType(current.ClassName, current.Name, current.ControlType, frameId, current.NativeWindowHandle != 0);
         }

--- a/src/TestStack.White/UIItems/Custom/CustomUIItem.cs
+++ b/src/TestStack.White/UIItems/Custom/CustomUIItem.cs
@@ -31,5 +31,34 @@ namespace TestStack.White.UIItems.Custom
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Allows setting value of Custom UI items
+        /// </summary>
+        public override void SetValue(object value)
+        {
+            //Look for value pattern in the object
+            var pattern = Pattern(ValuePattern.Pattern) as ValuePattern;
+            if (pattern != null)
+            {
+                pattern.SetValue(value.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Allows getting value of Custom UI items
+        /// </summary>
+        /// <returns>Value pattern value as a string</returns>
+        public string GetValue()
+        {
+            var pattern = Pattern(ValuePattern.Pattern) as ValuePattern;
+            if (pattern != null)
+            {
+                return pattern.Current.Value;
+            }
+
+            //If nothing found or pattern is not accessible return empty string
+            return string.Empty;
+        }
     }
 }


### PR DESCRIPTION
CustomUI controls can now support setting/getting value pattern values. Added try-catch to GetTestControlType as this was causing some null ref exceptions if the speficied control does not have a parent object which can be the case on some custom Windows Forms controls.